### PR TITLE
Fix JDBC type for DECIMAL columns; add test

### DIFF
--- a/src/main/java/org/duckdb/DuckDBDatabaseMetaData.java
+++ b/src/main/java/org/duckdb/DuckDBDatabaseMetaData.java
@@ -825,7 +825,7 @@ public class DuckDBDatabaseMetaData implements DatabaseMetaData {
                                   + "table_catalog AS 'TABLE_CAT', "
                                   + "table_schema AS 'TABLE_SCHEM', "
                                   + "table_name AS 'TABLE_NAME', "
-                                  + "column_name as 'COLUMN_NAME', " + makeDataMap("c.data_type", "DATA_TYPE") + ", "
+                                  + "column_name as 'COLUMN_NAME', " + makeDataMap("regexp_replace(c.data_type, '\\(.*\\)', '')", "DATA_TYPE") + ", "
                                   + "c.data_type AS 'TYPE_NAME', "
                                   + "NULL AS 'COLUMN_SIZE', NULL AS 'BUFFER_LENGTH', "
                                   + "numeric_precision AS 'DECIMAL_DIGITS', "

--- a/src/test/java/org/duckdb/test/Assertions.java
+++ b/src/test/java/org/duckdb/test/Assertions.java
@@ -21,9 +21,13 @@ public class Assertions {
     }
 
     public static void assertEquals(Object actual, Object expected) throws Exception {
+        assertEquals(actual, expected, "");
+    }
+    public static void assertEquals(Object actual, Object expected, String label) throws Exception {
         Function<Object, String> getClass = (Object a) -> a == null ? "null" : a.getClass().toString();
 
-        String message = String.format("\"%s\" (of %s) should equal \"%s\" (of %s)", actual, getClass.apply(actual),
+        String message = label.isEmpty() ? "" : label + ": ";
+        message += String.format("\"%s\" (of %s) should equal \"%s\" (of %s)", actual, getClass.apply(actual),
                                        expected, getClass.apply(expected));
         assertTrue(Objects.equals(actual, expected), message);
     }


### PR DESCRIPTION
This PR allows `DECIMAL(W,S)` types to be interpreted as `DECIMAL` JDBC type. Currently the type is returned as a generic `JAVA_OBJECT` because  `DECIMAL(W,S)` does not match ` `DECIMAL` in the case statement. This is similar to [0.9.2 behavior](https://github.com/duckdb/duckdb/blob/v0.9.2/tools/jdbc/src/main/java/org/duckdb/DuckDBDatabaseMetaData.java#L832) except the start-of-string matching is done in SQL rather than [Java](https://github.com/duckdb/duckdb/blob/v0.9.2/tools/jdbc/src/main/java/org/duckdb/DuckDBResultSetMetaData.java#L49).

I wonder if a better fix would be to use `data_type_id` from `duckdb_columns()` rather than `data_type` from `information_schema.columns`? It would require adding hardcoded duckdb type numbers into `DuckDBColumnType`. The test is useful either way.

There is a tiny unrelated improvement to `Assertions` utility, allowing the calling code to add a prefix to indicate which one of the loop iterations failed.

Fixes duckdb/duckdb#11365