### PR TITLE
Add get bytes

### DIFF
--- a/src/main/java/org/duckdb/DuckDBResultSet.java
+++ b/src/main/java/org/duckdb/DuckDBResultSet.java
@@ -359,7 +359,11 @@ public class DuckDBResultSet implements ResultSet {
     }
 
     public byte[] getBytes(int columnIndex) throws SQLException {
-        throw new SQLFeatureNotSupportedException("getBytes");
+        if (check_and_null(columnIndex)) {
+            return null;
+        }
+
+        return current_chunk[columnIndex - 1].getBytes(chunk_idx - 1);
     }
 
     public Date getDate(int columnIndex) throws SQLException {

--- a/src/main/java/org/duckdb/DuckDBVector.java
+++ b/src/main/java/org/duckdb/DuckDBVector.java
@@ -284,6 +284,22 @@ class DuckDBVector {
         throw new SQLFeatureNotSupportedException("getBlob");
     }
 
+    byte[] getBytes(int idx) throws SQLException {
+        if (check_and_null(idx)) {
+            return null;
+        }
+
+        if (isType(DuckDBColumnType.BLOB)) {
+            ByteBuffer bb = (ByteBuffer) varlen_data[idx];
+            bb.position(0);
+            byte [] bytes = new byte[bb.remaining()];
+            bb.get(bytes);
+            return bytes;
+        }
+
+        throw new SQLFeatureNotSupportedException("getBytes");
+    }
+
     JsonNode getJsonObject(int idx) {
         if (check_and_null(idx)) {
             return null;

--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -4357,7 +4357,7 @@ public class TestDuckDBJDBC {
             byte[][] arrays = new byte[][] {allTheBytes, {}};
 
             for(byte [] array : arrays ) {
-                s.setObject(1, array);
+                s.setBytes(1, array);
 
                 int rowsReturned = 0;
                 try (ResultSet rs = s.executeQuery()) {

--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -4344,6 +4344,25 @@ public class TestDuckDBJDBC {
         }
     }
 
+    public static void test_get_bytes_jakob() throws Exception {
+        try(Connection connection = DriverManager.getConnection("jdbc:duckdb:");
+            PreparedStatement s = connection.prepareStatement("select ?")) {
+
+            s.setObject(1, "these are some bytes".getBytes());
+            byte [] out;
+
+            try (ResultSet rs = s.executeQuery()) {
+                assertTrue(rs instanceof DuckDBResultSet);
+                while(rs.next()) {
+                    out = rs.getBytes(1);
+                    assertEquals(out, "these are some bytes".getBytes());
+                }
+            }
+
+        }
+
+    }
+
     public static void test_fractional_time() throws Exception {
         try (Connection conn = DriverManager.getConnection(JDBC_URL);
              PreparedStatement stmt = conn.prepareStatement("SELECT '01:02:03.123'::TIME");

--- a/src/test/java/org/duckdb/test/Assertions.java
+++ b/src/test/java/org/duckdb/test/Assertions.java
@@ -2,6 +2,7 @@ package org.duckdb.test;
 
 import org.duckdb.test.Thrower;
 
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Function;
 
@@ -23,13 +24,19 @@ public class Assertions {
     public static void assertEquals(Object actual, Object expected) throws Exception {
         assertEquals(actual, expected, "");
     }
+
     public static void assertEquals(Object actual, Object expected, String label) throws Exception {
         Function<Object, String> getClass = (Object a) -> a == null ? "null" : a.getClass().toString();
 
         String message = label.isEmpty() ? "" : label + ": ";
         message += String.format("\"%s\" (of %s) should equal \"%s\" (of %s)", actual, getClass.apply(actual),
                                        expected, getClass.apply(expected));
+        // Note this will fail for arrays, which do not implement .equals and so fall back to reference equality checks.
         assertTrue(Objects.equals(actual, expected), message);
+    }
+
+    public static void assertEquals(byte [] actual, byte [] expected, String message) throws Exception {
+        assertTrue(Arrays.equals(actual, expected), message);
     }
 
     public static void assertNotNull(Object a) throws Exception {


### PR DESCRIPTION
Fixes duckdb/duckdb-java#24.  

Adds support for the getBytes() method in DuckDBResultSet, along with accompanying unit test.