### PR TITLE
Make result set getColumn by name case insensitive.  Add test for same.

### DIFF
--- a/src/main/java/org/duckdb/DuckDBResultSet.java
+++ b/src/main/java/org/duckdb/DuckDBResultSet.java
@@ -311,7 +311,7 @@ public class DuckDBResultSet implements ResultSet {
             throw new SQLException("ResultSet was closed");
         }
         for (int col_idx = 0; col_idx < meta.column_count; col_idx++) {
-            if (meta.column_names[col_idx].contentEquals(columnLabel)) {
+            if (meta.column_names[col_idx].equalsIgnoreCase(columnLabel)) {
                 return col_idx + 1;
             }
         }

--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -4374,6 +4374,45 @@ public class TestDuckDBJDBC {
 
     }
 
+    public static void test_case_insensitivity() throws Exception {
+        try(Connection connection = DriverManager.getConnection("jdbc:duckdb:")) {
+            try(Statement s = connection.createStatement()) {
+                s.execute("CREATE TABLE someTable (lowercase INT, mixedCASE INT, UPPERCASE INT)");
+                s.execute("INSERT INTO someTable VALUES (0, 1, 2)");
+            }
+
+            String [] tableNameVariations = new String [] { "sometable", "someTable", "SOMETABLE"};
+            String [][] columnNameVariations = new String[][]{
+                    {"lowercase", "mixedcase", "uppercase"},
+                    {"lowerCASE", "mixedCASE", "upperCASE"},
+                    {"LOWERCASE", "MIXEDCASE", "UPPERCASE"}};
+
+            int totalTestsRun = 0;
+
+            // Test every combination of upper, lower and mixedcase column and table names.
+            for(String tableName : tableNameVariations) {
+                for(int columnVariation = 0; columnVariation < columnNameVariations.length; columnVariation++) {
+                    try (Statement s = connection.createStatement()) {
+                        String query = String.format("SELECT %s, %s, %s from %s;", columnNameVariations[0][0],
+                                columnNameVariations[0][1], columnNameVariations[0][2], tableName);
+
+                        ResultSet resultSet = s.executeQuery(query);
+                        assertTrue(resultSet.next());
+                        for(int i = 0; i < columnNameVariations[0].length; i++) {
+                            assertEquals(resultSet.getInt(columnNameVariations[columnVariation][i]), i,
+                                    "Query " + query + " did not get correct result back for column number " + i);
+                            totalTestsRun++;
+                        }
+                    }
+                }
+            }
+
+            assertEquals(totalTestsRun,
+                    tableNameVariations.length * columnNameVariations.length * columnNameVariations[0].length,
+                    "Number of test cases actually run did not match number expected to be run.");
+        }
+    }
+
     public static void test_fractional_time() throws Exception {
         try (Connection conn = DriverManager.getConnection(JDBC_URL);
              PreparedStatement stmt = conn.prepareStatement("SELECT '01:02:03.123'::TIME");


### PR DESCRIPTION
Fixes #40 .  Adds unit test both for column names from resultset as well as tablename itself, since we're already there.

This uses `equalsIgnoreCase` rather than the previous `contentEquals,' which is ever so slightly different (String to String versus String to CharSequence/String/StringBuffer, respectively), but I think that shouldn't make a difference in these use cases. 