### PR TITLE
Always upload combined JAR even if Maven upload fails

### DIFF
--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -260,7 +260,9 @@ jobs:
           fi
           ls -lahR jdbc-artifacts
 
-      - uses: actions/upload-artifact@v3
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
         with:
           name: java-jars
           path: |


### PR DESCRIPTION
Uploading this artifact currently relies on the upload to Maven succeeding because it's uploaded within the same step. However, we'd like to have the combined JAR available even if it does not succeed (which is very often). This PR separates this step and allows it to always run even if the previous step failed.