### PR TITLE
Trigger rebuild also on Nightly

### DIFF
--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -2,6 +2,7 @@ name: Java JDBC
 on:
   push:
   pull_request:
+  workflow_call:
   workflow_dispatch:
   repository_dispatch:
 

--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -5,12 +5,7 @@ on:
     paths:
       - ".github/workflows/Nightly.yml"
       - "vendor.py"
-#  workflow_dispatch:
-#    inputs:
-#      # Git ref of the duckdb repo
-#      duckdb-ref:
-#        required: true
-#        type: string
+  workflow_dispatch:
   schedule:
     - cron: "17 0 * * *"
 
@@ -20,7 +15,7 @@ jobs:
   vendor:
     runs-on: ubuntu-latest
     outputs:
-      sha: ${{ steps.commit.outputs.sha }}
+      did_vendor: ${{ steps.vendor.outputs.vendor }}
 
     name: "Update vendored sources"
     if: github.repository == 'duckdb/duckdb-java'
@@ -62,3 +57,9 @@ jobs:
       - if: steps.vendor.outputs.vendor != '' && github.event_name != 'pull_request'
         run: |
           git push -u origin HEAD
+
+  rebuild:
+    needs: vendor
+    if: ${{ needs.vendor.outputs.did_vendor != '' }}
+    uses: ./.github/workflows/Java.yml
+    secrets: inherit


### PR DESCRIPTION
Trigger rebuild (= then deployed on latest) also for nightly vendoring script.

I have tested this on my fork, looks to be working as intended, but possibly some permissions might be off, unsure, we will need to check whether it works in the proper context to double check.

Pinging @lnkuiper, that pinged on this.