### PR TITLE
Allow escaping in schema reflection - with test

### DIFF
--- a/src/main/java/org/duckdb/DuckDBDatabaseMetaData.java
+++ b/src/main/java/org/duckdb/DuckDBDatabaseMetaData.java
@@ -243,7 +243,7 @@ public class DuckDBDatabaseMetaData implements DatabaseMetaData {
 
     @Override
     public String getSearchStringEscape() throws SQLException {
-        return null;
+        return "\\";
     }
 
     @Override
@@ -719,7 +719,7 @@ public class DuckDBDatabaseMetaData implements DatabaseMetaData {
             if (schemaPattern.isEmpty()) {
                 sb.append("schema_name IS NULL");
             } else {
-                sb.append("schema_name LIKE ?");
+                sb.append("schema_name LIKE ? ESCAPE '\\'");
             }
             sb.append(lineSeparator());
         }
@@ -784,7 +784,7 @@ public class DuckDBDatabaseMetaData implements DatabaseMetaData {
             // non-standard behavior.
             tableNamePattern = "%";
         }
-        str.append("WHERE table_name LIKE ?").append(lineSeparator());
+        str.append("WHERE table_name LIKE ? ESCAPE '\\'").append(lineSeparator());
 
         // catalog - a catalog name; must match the catalog name as it is stored in
         // the database;
@@ -811,7 +811,7 @@ public class DuckDBDatabaseMetaData implements DatabaseMetaData {
             if (schemaPattern.isEmpty()) {
                 str.append("IS NULL").append(lineSeparator());
             } else {
-                str.append("LIKE ?").append(lineSeparator());
+                str.append("LIKE ? ESCAPE '\\'").append(lineSeparator());
                 hasSchemaParam = true;
             }
         }
@@ -896,10 +896,10 @@ public class DuckDBDatabaseMetaData implements DatabaseMetaData {
                                   + "'' AS 'IS_AUTOINCREMENT', "
                                   + "'' AS 'IS_GENERATEDCOLUMN' "
                                   + "FROM information_schema.columns c "
-                                  + "WHERE table_catalog LIKE ? AND "
-                                  + "table_schema LIKE ? AND "
-                                  + "table_name LIKE ? AND "
-                                  + "column_name LIKE ? "
+                                  + "WHERE table_catalog LIKE ? ESCAPE '\\' AND "
+                                  + "table_schema LIKE ? ESCAPE '\\' AND "
+                                  + "table_name LIKE ? ESCAPE '\\' AND "
+                                  + "column_name LIKE ? ESCAPE '\\' "
                                   + "ORDER BY \"TABLE_CAT\",\"TABLE_SCHEM\", \"TABLE_NAME\", \"ORDINAL_POSITION\"");
         ps.setString(1, catalogPattern);
         ps.setString(2, schemaPattern);

--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -1746,6 +1746,29 @@ public class TestDuckDBJDBC {
         stmt.close();
         conn.close();
     }
+    public static void test_wildcard_reflection() throws Exception {
+        Connection conn = DriverManager.getConnection(JDBC_URL);
+        Statement stmt = conn.createStatement();
+        stmt.execute("CREATE TABLE _a (_i INTEGER, xi INTEGER)");
+        stmt.execute("CREATE TABLE xa (i INTEGER)");
+
+        DatabaseMetaData md = conn.getMetaData();
+        ResultSet rs;
+        rs = md.getTables(null, null, "\\_a", null);
+        assertTrue(rs.next());
+        assertEquals(rs.getString("TABLE_NAME"), "_a");
+        assertFalse(rs.next());
+        rs.close();
+
+        rs = md.getColumns(null, DuckDBConnection.DEFAULT_SCHEMA, "\\_a", "\\_i");
+        assertTrue(rs.next());
+        assertEquals(rs.getString("TABLE_NAME"), "_a");
+        assertEquals(rs.getString("COLUMN_NAME"), "_i");
+        assertFalse(rs.next());
+
+        rs.close();
+        conn.close();
+    }
 
     public static void test_schema_reflection() throws Exception {
         Connection conn = DriverManager.getConnection(JDBC_URL);


### PR DESCRIPTION
This allows using \ to escape the LIKE expressions in schema reflection.