### PR TITLE
Use a single transaction per batch

### DIFF
--- a/src/main/java/org/duckdb/DuckDBPreparedStatement.java
+++ b/src/main/java/org/duckdb/DuckDBPreparedStatement.java
@@ -124,6 +124,10 @@ public class DuckDBPreparedStatement implements PreparedStatement {
 
     @Override
     public boolean execute() throws SQLException {
+        return execute(true);
+    }
+
+    private boolean execute(boolean startTransaction) throws SQLException {
         if (isClosed()) {
             throw new SQLException("Statement was closed");
         }
@@ -138,7 +142,9 @@ public class DuckDBPreparedStatement implements PreparedStatement {
         select_result = null;
 
         try {
-            startTransaction();
+            if (startTransaction) {
+                startTransaction();
+            }
             result_ref = DuckDBNative.duckdb_jdbc_execute(stmt_ref, params);
             DuckDBResultSetMetaData result_meta = DuckDBNative.duckdb_jdbc_query_result_meta(result_ref);
             select_result = new DuckDBResultSet(this, result_meta, result_ref, conn.conn_ref);
@@ -476,9 +482,11 @@ public class DuckDBPreparedStatement implements PreparedStatement {
 
     private int[] executeBatchedPreparedStatement() throws SQLException {
         int[] updateCounts = new int[this.batchedParams.size()];
+
+        startTransaction();
         for (int i = 0; i < this.batchedParams.size(); i++) {
             params = this.batchedParams.get(i);
-            execute();
+            execute(false);
             updateCounts[i] = getUpdateCount();
         }
         return updateCounts;
@@ -486,9 +494,11 @@ public class DuckDBPreparedStatement implements PreparedStatement {
 
     private int[] executeBatchedStatements() throws SQLException {
         int[] updateCounts = new int[this.batchedStatements.size()];
+
+        startTransaction();
         for (int i = 0; i < this.batchedStatements.size(); i++) {
             prepare(this.batchedStatements.get(i));
-            execute();
+            execute(false);
             updateCounts[i] = getUpdateCount();
         }
         return updateCounts;


### PR DESCRIPTION
I realize that one use the Appender instead, but I did notice that we force a transaction per row even when auto-commit is off.

This uses a transaction per batch instead. Looks like this is already covered in the tests, please let me know if you think that's not sufficient.

Roughly a 2x improvement in tests (this is a using DuckDB from Trino).