### PR TITLE
Expose db memory address and path to libduckdb_java.so V2

### DIFF
--- a/src/jni/duckdb_java.cpp
+++ b/src/jni/duckdb_java.cpp
@@ -397,6 +397,12 @@ struct ConnectionHolder {
 	}
 };
 
+// Returns the pointer's memory address of duckdb::DuckDB as a jlong
+jlong _duckdb_jdbc_db_memory_address(JNIEnv *env, jclass, jobject conn_ref_buf) {
+	auto conn_ref = (ConnectionHolder *)env->GetDirectBufferAddress(conn_ref_buf);
+	return (jlong)conn_ref->db.get();
+}
+
 /**
  * Throws a SQLException and returns nullptr if a valid Connection can't be retrieved from the buffer.
  */

--- a/src/jni/functions.cpp
+++ b/src/jni/functions.cpp
@@ -26,6 +26,17 @@ JNIEXPORT jobject JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1connect(JNI
 	}
 }
 
+JNIEXPORT jlong JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1db_1memory_1address(JNIEnv * env, jclass param0, jobject param1) {
+	try {
+		return _duckdb_jdbc_db_memory_address(env, param0, param1);
+	} catch (const std::exception &e) {
+		duckdb::ErrorData error(e);
+		ThrowJNI(env, error.Message().c_str());
+
+		return -1;
+	}
+}
+
 JNIEXPORT void JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1set_1auto_1commit(JNIEnv * env, jclass param0, jobject param1, jboolean param2) {
 	try {
 		return _duckdb_jdbc_set_auto_commit(env, param0, param1, param2);

--- a/src/jni/functions.hpp
+++ b/src/jni/functions.hpp
@@ -17,6 +17,10 @@ jobject _duckdb_jdbc_connect(JNIEnv * env, jclass param0, jobject param1);
 
 JNIEXPORT jobject JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1connect(JNIEnv * env, jclass param0, jobject param1);
 
+jlong _duckdb_jdbc_db_memory_address(JNIEnv * env, jclass param0, jobject param1);
+
+JNIEXPORT jlong JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1db_1memory_1address(JNIEnv * env, jclass param0, jobject param1);
+
 void _duckdb_jdbc_set_auto_commit(JNIEnv * env, jclass param0, jobject param1, jboolean param2);
 
 JNIEXPORT void JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1set_1auto_1commit(JNIEnv * env, jclass param0, jobject param1, jboolean param2);

--- a/src/main/java/org/duckdb/DuckDBConnection.java
+++ b/src/main/java/org/duckdb/DuckDBConnection.java
@@ -371,4 +371,26 @@ public final class DuckDBConnection implements java.sql.Connection {
         long array_stream_address = getArrowStreamAddress(arrow_array_stream);
         DuckDBNative.duckdb_jdbc_arrow_register(conn_ref, array_stream_address, name.getBytes(StandardCharsets.UTF_8));
     }
+
+    /**
+     * <p>Gets the memory address of the DuckDB C++ object from within JNI. With this it is possible to create
+     * database connections outside the JDBC driver.</p>
+     * <p><b>Big warning:</b> The JDBC driver does not know anything about these outside connection! Closing the
+     * database must happen with JDBC! Using outside connections implies keeping at least one JDBC connection open to
+     * avoid accessing freed memory!</p>
+     * @return The memory address as a Java long. 0 indicates no open connection.
+     */
+    public long getDuckDBMemoryAddress() {
+        if (this.conn_ref != null) {
+            return DuckDBNative.duckdb_jdbc_db_memory_address(this.conn_ref);
+        }
+        return 0;
+    }
+
+    /**
+     * <p>Gets the path and temporal file name of the duckdb_java lib as it was loaded via System.load().</p>
+     */
+    public String getDuckDBResourceFile() {
+        return DuckDBNative.getDuckDBResourceFile();
+    }
 }

--- a/src/main/java/org/duckdb/DuckDBNative.java
+++ b/src/main/java/org/duckdb/DuckDBNative.java
@@ -50,17 +50,27 @@ class DuckDBNative {
             URL lib_res = DuckDBNative.class.getResource(lib_res_name);
             if (lib_res == null) {
                 System.load(Paths.get("build/debug", lib_res_name).normalize().toAbsolutePath().toString());
+                duckDBResourceFile = Paths.get("build/debug", lib_res_name).normalize().toAbsolutePath().toString();
             } else {
                 try (final InputStream lib_res_input_stream = lib_res.openStream()) {
                     Files.copy(lib_res_input_stream, lib_file, StandardCopyOption.REPLACE_EXISTING);
                 }
                 new File(lib_file.toString()).deleteOnExit();
                 System.load(lib_file.toAbsolutePath().toString());
+                duckDBResourceFile = lib_file.toAbsolutePath().toString();
             }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
+
+    // Full path and name of the libduckdb_java.so
+    private static final String duckDBResourceFile;
+
+    protected static String getDuckDBResourceFile() {
+        return duckDBResourceFile;
+    }
+
     // We use zero-length ByteBuffer-s as a hacky but cheap way to pass C++ pointers
     // back and forth
 
@@ -75,6 +85,8 @@ class DuckDBNative {
 
     // returns conn_ref connection reference object
     protected static native ByteBuffer duckdb_jdbc_connect(ByteBuffer db_ref) throws SQLException;
+
+    protected static native long duckdb_jdbc_db_memory_address(ByteBuffer conn_ref);
 
     protected static native void duckdb_jdbc_set_auto_commit(ByteBuffer conn_ref, boolean auto_commit)
         throws SQLException;

--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.SecureRandom;
 import java.sql.*;
 import java.time.Instant;
@@ -166,11 +167,11 @@ public class TestDuckDBJDBC {
 
         // Unfortunately it seems to be impossible to test the memory
         // address without writing test code inside jni. So the only test here
-        // is that the result is a long and it is not 0.
+        // is that the result is a long and it is not 0 or negative.
 
         long memoryAddress = ((DuckDBConnection) conn).getDuckDBMemoryAddress();
         assertTrue(Long.class.isInstance(memoryAddress));
-        assertFalse(memoryAddress == 0);
+        assertTrue(memoryAddress > 0);
         conn.close();
     }
 

--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -149,6 +149,31 @@ public class TestDuckDBJDBC {
         assertThrows(conn::createStatement, SQLException.class);
     }
 
+    public static void test_duckdb_path_to_lib() throws Exception {
+        Connection conn = DriverManager.getConnection(JDBC_URL);
+        assertTrue(conn.isValid(0));
+        assertFalse(conn.isClosed());
+
+        Path libPath = Paths.get(((DuckDBConnection) conn).getDuckDBResourceFile());
+        assertTrue(Files.exists(libPath));
+        conn.close();
+    }
+
+    public static void test_duckdb_memory_address() throws Exception {
+        Connection conn = DriverManager.getConnection(JDBC_URL);
+        assertTrue(conn.isValid(0));
+        assertFalse(conn.isClosed());
+
+        // Unfortunately it seems to be impossible to test the memory
+        // address without writing test code inside jni. So the only test here
+        // is that the result is a long and it is not 0.
+
+        long memoryAddress = ((DuckDBConnection) conn).getDuckDBMemoryAddress();
+        assertTrue(Long.class.isInstance(memoryAddress));
+        assertFalse(memoryAddress == 0);
+        conn.close();
+    }
+
     public static void test_prepare_exception() throws Exception {
         Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();


### PR DESCRIPTION
This PR replaces #87!

Same idea, but:
- using Java long instead of String to hold the memory address
- based on top of main HEAD

I read that DuckDB uses pointer swizzling, which should break before there is problem with the uintptr_t -> jlong cast. This means it should be OK to use it on all supported platforms.


