### PR TITLE
Modify UUID when passing it as a bind variable

### DIFF
--- a/src/jni/duckdb_java.cpp
+++ b/src/jni/duckdb_java.cpp
@@ -13,6 +13,9 @@
 #include "duckdb/parser/parsed_data/create_type_info.hpp"
 #include "functions.hpp"
 
+#include <cstdint>
+#include <limits>
+
 using namespace duckdb;
 using namespace std;
 
@@ -625,6 +628,9 @@ Value ToValue(JNIEnv *env, jobject param, duckdb::shared_ptr<ClientContext> cont
 		return (Value::BLOB_RAW(byte_array_to_string(env, (jbyteArray)param)));
 	} else if (env->IsInstanceOf(param, J_UUID)) {
 		auto most_significant = (jlong)env->CallObjectMethod(param, J_UUID_getMostSignificantBits);
+		// Account for the following logic in UUID::FromString:
+		// Flip the first bit to make `order by uuid` same as `order by uuid::varchar`
+		most_significant ^= (std::numeric_limits<int64_t>::min)();
 		auto least_significant = (jlong)env->CallObjectMethod(param, J_UUID_getLeastSignificantBits);
 		return (Value::UUID(hugeint_t(most_significant, least_significant)));
 	} else if (env->IsInstanceOf(param, J_DuckMap)) {

--- a/src/main/java/org/duckdb/DuckDBVector.java
+++ b/src/main/java/org/duckdb/DuckDBVector.java
@@ -228,9 +228,10 @@ class DuckDBVector {
         if (isType(DuckDBColumnType.UUID)) {
             ByteBuffer buffer = getbuf(idx, 16);
             long leastSignificantBits = buffer.getLong();
-
-            // Account for unsigned
-            long mostSignificantBits = buffer.getLong() - Long.MAX_VALUE - 1;
+            long mostSignificantBits = buffer.getLong();
+            // Account for the following logic in UUID::FromString:
+            // Flip the first bit to make `order by uuid` same as `order by uuid::varchar`
+            mostSignificantBits ^= Long.MIN_VALUE;
             return new UUID(mostSignificantBits, leastSignificantBits);
         }
         Object o = getObject(idx);


### PR DESCRIPTION
When parsing an UUID from a string literal DuckDB modifies it with [flipping the most significant bit](https://github.com/duckdb/duckdb/blob/c9dd40f144e07a5dddb1d81c7218555205894c80/src/common/types/uuid.cpp#L51) in `UUID::FromString` for the following reason:

"Flip the first bit to make `order by uuid` same as `order by uuid::varchar`"

When an UUID is read from a result set, JDBC driver flips the MSB again to get back the original UUID in Java.

This bit-flipping logic was missing when an UUID was passed from Java as a bind variable. The proposed change adds the same logic when passing bind variables.

Testing: existing test is improved to cover both string literal and a bind variable.

Fixes: #147