### PR TITLE
Update upload-artifact action to v4

### DIFF
--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           cp build/release/duckdb_jdbc.jar duckdb_jdbc-linux-amd64.jar
           ./scripts/upload-assets-to-staging.sh github_release duckdb_jdbc-linux-amd64.jar
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: java-linux-amd64
           path: |
@@ -108,7 +108,7 @@ jobs:
           cp build/release/duckdb_jdbc.jar duckdb_jdbc-linux-aarch64.jar
          # ./scripts/upload-assets-to-staging.sh github_release duckdb_jdbc-linux-aarch64.jar
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: java-linux-aarch64
           path: |
@@ -150,7 +150,7 @@ jobs:
         run: |
           cp build/release/duckdb_jdbc.jar duckdb_jdbc-windows-amd64.jar
           ./scripts/upload-assets-to-staging.sh github_release duckdb_jdbc-windows-amd64.jar
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: java-windows-amd64
           path: |
@@ -192,7 +192,7 @@ jobs:
         run: |
           cp build/release/duckdb_jdbc.jar duckdb_jdbc-osx-universal.jar
           ./scripts/upload-assets-to-staging.sh github_release duckdb_jdbc-osx-universal.jar
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: java-osx-universal
           path: |
@@ -267,7 +267,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: java-jars
           path: |


### PR DESCRIPTION
This action needs to be updated to allow workflow runs, [details](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/).