### PR TITLE
Support spatial extension types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -560,6 +560,7 @@ add_library(duckdb_java SHARED
   src/jni/duckdb_java.cpp
   src/jni/functions.cpp
   src/jni/refs.cpp
+  src/jni/types.cpp
   src/jni/util.cpp
   ${DUCKDB_SRC_FILES})
 

--- a/src/jni/types.cpp
+++ b/src/jni/types.cpp
@@ -1,0 +1,45 @@
+#include "types.hpp"
+
+#include <string>
+#include <vector>
+
+std::string type_to_jduckdb_type(duckdb::LogicalType logical_type) {
+	switch (logical_type.id()) {
+	case duckdb::LogicalTypeId::DECIMAL: {
+
+		uint8_t width = 0;
+		uint8_t scale = 0;
+		logical_type.GetDecimalProperties(width, scale);
+		std::string width_scale = std::to_string(width) + std::string(";") + std::to_string(scale);
+
+		auto physical_type = logical_type.InternalType();
+		switch (physical_type) {
+		case duckdb::PhysicalType::INT16: {
+			std::string res = std::string("DECIMAL16;") + width_scale;
+			return res;
+		}
+		case duckdb::PhysicalType::INT32: {
+			std::string res = std::string("DECIMAL32;") + width_scale;
+			return res;
+		}
+		case duckdb::PhysicalType::INT64: {
+			std::string res = std::string("DECIMAL64;") + width_scale;
+			return res;
+		}
+		case duckdb::PhysicalType::INT128: {
+			std::string res = std::string("DECIMAL128;") + width_scale;
+			return res;
+		}
+		default:
+			return std::string("no physical type found");
+		}
+	} break;
+	default:
+		// JSON requires special handling because it is mapped
+		// to JsonNode class
+		if (logical_type.IsJSONType()) {
+			return logical_type.GetAlias();
+		}
+		return duckdb::EnumUtil::ToString(logical_type.id());
+	}
+}

--- a/src/jni/types.hpp
+++ b/src/jni/types.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "duckdb.hpp"
+
+std::string type_to_jduckdb_type(duckdb::LogicalType logical_type);

--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -11,14 +11,7 @@ import static java.util.Collections.singletonList;
 import static org.duckdb.DuckDBDriver.DUCKDB_USER_AGENT_PROPERTY;
 import static org.duckdb.DuckDBDriver.JDBC_STREAM_RESULTS;
 import static org.duckdb.DuckDBTimestamp.localDateTimeFromTimestamp;
-import static org.duckdb.test.Assertions.assertEquals;
-import static org.duckdb.test.Assertions.assertFalse;
-import static org.duckdb.test.Assertions.assertNotNull;
-import static org.duckdb.test.Assertions.assertNull;
-import static org.duckdb.test.Assertions.assertThrows;
-import static org.duckdb.test.Assertions.assertThrowsMaybe;
-import static org.duckdb.test.Assertions.assertTrue;
-import static org.duckdb.test.Assertions.fail;
+import static org.duckdb.test.Assertions.*;
 import static org.duckdb.test.Runner.runTests;
 
 import java.math.BigDecimal;
@@ -1302,7 +1295,7 @@ public class TestDuckDBJDBC {
         conn.close();
     }
 
-    public static void test_big_data() throws Exception {
+    public static void test_lots_of_big_data() throws Exception {
         Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
         int rows = 10000;
@@ -4187,21 +4180,6 @@ public class TestDuckDBJDBC {
         return result;
     }
 
-    private static <T> void assertListsEqual(List<T> actual, List<T> expected) throws Exception {
-        assertListsEqual(actual, expected, "");
-    }
-
-    private static <T> void assertListsEqual(List<T> actual, List<T> expected, String label) throws Exception {
-        assertEquals(actual.size(), expected.size());
-
-        ListIterator<T> itera = actual.listIterator();
-        ListIterator<T> itere = expected.listIterator();
-
-        while (itera.hasNext()) {
-            assertEquals(itera.next(), itere.next(), label);
-        }
-    }
-
     public static void test_cancel() throws Exception {
         ExecutorService service = Executors.newFixedThreadPool(1);
         try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement()) {
@@ -4300,7 +4278,7 @@ public class TestDuckDBJDBC {
         }
     }
 
-    public static void test_race() throws Exception {
+    public static void test_lots_of_races() throws Exception {
         try (Connection connection = DriverManager.getConnection(JDBC_URL)) {
             ExecutorService executorService = Executors.newFixedThreadPool(10);
 
@@ -4799,6 +4777,15 @@ public class TestDuckDBJDBC {
     }
 
     public static void main(String[] args) throws Exception {
-        System.exit(runTests(args, TestDuckDBJDBC.class, TestExtensionTypes.class));
+        String arg1 = args.length > 0 ? args[0] : "";
+        final int statusCode;
+        if (arg1.startsWith("Test")) {
+            Class<?> clazz = Class.forName("org.duckdb." + arg1);
+            statusCode = runTests(new String[0], clazz);
+        } else {
+            // extension installation fails on CI, Spatial test is temporary disabled
+            statusCode = runTests(args, TestDuckDBJDBC.class, TestExtensionTypes.class /*, TestSpatial.class */);
+        }
+        System.exit(statusCode);
     }
 }

--- a/src/test/java/org/duckdb/TestExtensionTypes.java
+++ b/src/test/java/org/duckdb/TestExtensionTypes.java
@@ -3,12 +3,7 @@ package org.duckdb;
 import static org.duckdb.TestDuckDBJDBC.JDBC_URL;
 import static org.duckdb.test.Assertions.assertEquals;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.Statement;
-import java.sql.Types;
+import java.sql.*;
 
 public class TestExtensionTypes {
 
@@ -21,8 +16,14 @@ public class TestExtensionTypes {
             try (ResultSet rs = stmt.executeQuery(
                      "SELECT {\"hello\": 'foo', \"world\": 'bar'}::test_type, '\\xAA'::byte_test_type")) {
                 rs.next();
-                assertEquals(rs.getObject(1), "{'hello': foo, 'world': bar}");
-                assertEquals(rs.getObject(2), "\\xAA");
+                Struct struct = (Struct) rs.getObject(1);
+                Object[] attrs = struct.getAttributes();
+                assertEquals(attrs[0], "foo");
+                assertEquals(attrs[1], "bar");
+                Blob blob = rs.getBlob(2);
+                byte[] bytes = blob.getBytes(1, (int) blob.length());
+                assertEquals(bytes.length, 1);
+                assertEquals(bytes[0] & 0xff, 0xaa);
             }
         }
     }

--- a/src/test/java/org/duckdb/TestSpatial.java
+++ b/src/test/java/org/duckdb/TestSpatial.java
@@ -1,0 +1,352 @@
+package org.duckdb;
+
+import static org.duckdb.TestDuckDBJDBC.JDBC_URL;
+import static org.duckdb.test.Assertions.assertEquals;
+import static org.duckdb.test.Assertions.assertListsEqual;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestSpatial {
+
+    public static void test_spatial_POINT_2D() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate("INSTALL spatial");
+            stmt.executeUpdate("LOAD spatial");
+
+            // POINT_2D literal
+            try (ResultSet rs = stmt.executeQuery("SELECT ST_Point2D(41.1, 42.2)")) {
+                rs.next();
+                Object obj = rs.getObject(1);
+                DuckDBStruct struct = (DuckDBStruct) obj;
+                assertEquals(41.1d, struct.getMap().get("x"));
+                assertEquals(42.2d, struct.getMap().get("y"));
+            }
+
+            // POINT_2D parameter
+            try (PreparedStatement ps = conn.prepareStatement("SELECT ?::POINT_2D")) {
+                Struct param = conn.createStruct("POINT_2D", new Object[] {41.1d, 42.2d});
+                ps.setObject(1, param);
+                try (ResultSet rs = ps.executeQuery()) {
+                    rs.next();
+                    Object obj = rs.getObject(1);
+                    DuckDBStruct struct = (DuckDBStruct) obj;
+                    assertEquals(41.1d, struct.getMap().get("x"));
+                    assertEquals(42.2d, struct.getMap().get("y"));
+                }
+            }
+        }
+    }
+
+    public static void test_spatial_POINT_3D() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate("INSTALL spatial");
+            stmt.executeUpdate("LOAD spatial");
+
+            // POINT_3D literal
+            try (ResultSet rs = stmt.executeQuery("SELECT ST_Point3D(41.1, 42.2, 43.3)")) {
+                rs.next();
+                Object obj = rs.getObject(1);
+                DuckDBStruct struct = (DuckDBStruct) obj;
+                assertEquals(41.1d, struct.getMap().get("x"));
+                assertEquals(42.2d, struct.getMap().get("y"));
+                assertEquals(43.3d, struct.getMap().get("z"));
+            }
+
+            // POINT_3D parameter
+            try (PreparedStatement ps = conn.prepareStatement("SELECT ?::POINT_3D")) {
+                Struct param = conn.createStruct("POINT_3D", new Object[] {41.1d, 42.2d, 43.3d});
+                ps.setObject(1, param);
+                try (ResultSet rs = ps.executeQuery()) {
+                    rs.next();
+                    Object obj = rs.getObject(1);
+                    DuckDBStruct struct = (DuckDBStruct) obj;
+                    assertEquals(41.1d, struct.getMap().get("x"));
+                    assertEquals(42.2d, struct.getMap().get("y"));
+                    assertEquals(43.3d, struct.getMap().get("z"));
+                }
+            }
+        }
+    }
+
+    public static void test_spatial_POINT_4D() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate("INSTALL spatial");
+            stmt.executeUpdate("LOAD spatial");
+
+            // POINT_4D literal
+            try (ResultSet rs = stmt.executeQuery("SELECT ST_Point4D(41.1, 42.2, 43.3, 44.4)")) {
+                rs.next();
+                Object obj = rs.getObject(1);
+                DuckDBStruct struct = (DuckDBStruct) obj;
+                assertEquals(41.1d, struct.getMap().get("x"));
+                assertEquals(42.2d, struct.getMap().get("y"));
+                assertEquals(43.3d, struct.getMap().get("z"));
+                assertEquals(44.4d, struct.getMap().get("m"));
+            }
+
+            // POINT_4D parameter
+            try (PreparedStatement ps = conn.prepareStatement("SELECT ?::POINT_4D")) {
+                Struct param = conn.createStruct("POINT_4D", new Object[] {41.1d, 42.2d, 43.3d, 44.4d});
+                ps.setObject(1, param);
+                try (ResultSet rs = ps.executeQuery()) {
+                    rs.next();
+                    Object obj = rs.getObject(1);
+                    DuckDBStruct struct = (DuckDBStruct) obj;
+                    assertEquals(41.1d, struct.getMap().get("x"));
+                    assertEquals(42.2d, struct.getMap().get("y"));
+                    assertEquals(43.3d, struct.getMap().get("z"));
+                    assertEquals(44.4d, struct.getMap().get("m"));
+                }
+            }
+        }
+    }
+
+    public static void test_spatial_BOX_2D() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate("INSTALL spatial");
+            stmt.executeUpdate("LOAD spatial");
+
+            // BOX_2D literal
+            try (ResultSet rs = stmt.executeQuery("SELECT ST_Extent(ST_Point(41.1, 42.2))")) {
+                rs.next();
+                Object obj = rs.getObject(1);
+                DuckDBStruct struct = (DuckDBStruct) obj;
+                assertEquals(41.1d, struct.getMap().get("min_x"));
+                assertEquals(42.2d, struct.getMap().get("min_y"));
+                assertEquals(41.1d, struct.getMap().get("max_x"));
+                assertEquals(42.2d, struct.getMap().get("max_y"));
+            }
+
+            // BOX_2D parameter
+            try (PreparedStatement ps = conn.prepareStatement("SELECT ?::BOX_2D")) {
+                Struct param = conn.createStruct("BOX_2D", new Object[] {41.1d, 42.2d, 43.3d, 44.4d});
+                ps.setObject(1, param);
+                try (ResultSet rs = ps.executeQuery()) {
+                    rs.next();
+                    Object obj = rs.getObject(1);
+                    DuckDBStruct struct = (DuckDBStruct) obj;
+                    assertEquals(41.1d, struct.getMap().get("min_x"));
+                    assertEquals(42.2d, struct.getMap().get("min_y"));
+                    assertEquals(43.3d, struct.getMap().get("max_x"));
+                    assertEquals(44.4d, struct.getMap().get("max_y"));
+                }
+            }
+        }
+    }
+
+    public static void test_spatial_BOX_2DF() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate("INSTALL spatial");
+            stmt.executeUpdate("LOAD spatial");
+
+            // BOX_2DF literal
+            try (ResultSet rs = stmt.executeQuery(
+                     "SELECT STRUCT_PACK(min_x := 41.1, min_y := 42.2, max_x := 43.3, max_y := 44.4)::BOX_2DF")) {
+                rs.next();
+                Object obj = rs.getObject(1);
+                DuckDBStruct struct = (DuckDBStruct) obj;
+                assertEquals(41.1f, struct.getMap().get("min_x"));
+                assertEquals(42.2f, struct.getMap().get("min_y"));
+                assertEquals(43.3f, struct.getMap().get("max_x"));
+                assertEquals(44.4f, struct.getMap().get("max_y"));
+            }
+
+            // BOX_2DF parameter
+            try (PreparedStatement ps = conn.prepareStatement("SELECT ?::BOX_2DF")) {
+                Struct param = conn.createStruct("BOX_2DF", new Object[] {41.1f, 42.2f, 43.3f, 44.4f});
+                ps.setObject(1, param);
+                try (ResultSet rs = ps.executeQuery()) {
+                    rs.next();
+                    Object obj = rs.getObject(1);
+                    DuckDBStruct struct = (DuckDBStruct) obj;
+                    assertEquals(41.1f, struct.getMap().get("min_x"));
+                    assertEquals(42.2f, struct.getMap().get("min_y"));
+                    assertEquals(43.3f, struct.getMap().get("max_x"));
+                    assertEquals(44.4f, struct.getMap().get("max_y"));
+                }
+            }
+        }
+    }
+
+    public static void test_spatial_LINESTRING_2D() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate("INSTALL spatial");
+            stmt.executeUpdate("LOAD spatial");
+
+            // LINESTRING_2D literal
+            try (ResultSet rs = stmt.executeQuery("SELECT ARRAY["
+                                                  + "STRUCT_PACK(x := 41.1, y := 42.2),"
+                                                  + "STRUCT_PACK(x := 43.3, y := 44.4)"
+                                                  + "]::LINESTRING_2D")) {
+                rs.next();
+                Array array = rs.getArray(1);
+                Object[] arr = (Object[]) array.getArray();
+                DuckDBStruct struct1 = (DuckDBStruct) arr[0];
+                assertEquals(41.1d, struct1.getMap().get("x"));
+                assertEquals(42.2d, struct1.getMap().get("y"));
+                DuckDBStruct struct2 = (DuckDBStruct) arr[1];
+                assertEquals(43.3d, struct2.getMap().get("x"));
+                assertEquals(44.4d, struct2.getMap().get("y"));
+            }
+
+            // LINESTRING_2D parameter
+            try (PreparedStatement ps = conn.prepareStatement("SELECT ?::LINESTRING_2D")) {
+                Struct point1 = conn.createStruct("POINT_2D", new Object[] {41.1d, 42.2d});
+                Struct point2 = conn.createStruct("POINT_2D", new Object[] {43.3d, 44.4d});
+                Array param = conn.createArrayOf("POINT_2D", new Object[] {point1, point2});
+                ps.setObject(1, param);
+                try (ResultSet rs = ps.executeQuery()) {
+                    rs.next();
+                    Array array = rs.getArray(1);
+                    Object[] arr = (Object[]) array.getArray();
+                    DuckDBStruct struct1 = (DuckDBStruct) arr[0];
+                    assertEquals(41.1d, struct1.getMap().get("x"));
+                    assertEquals(42.2d, struct1.getMap().get("y"));
+                    DuckDBStruct struct2 = (DuckDBStruct) arr[1];
+                    assertEquals(43.3d, struct2.getMap().get("x"));
+                    assertEquals(44.4d, struct2.getMap().get("y"));
+                }
+            }
+        }
+    }
+
+    public static void test_spatial_POLYGON_2D() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate("INSTALL spatial");
+            stmt.executeUpdate("LOAD spatial");
+
+            // POLYGON_2D literal
+            try (ResultSet rs = stmt.executeQuery("SELECT ARRAY[ARRAY["
+                                                  + "STRUCT_PACK(x := 41.1, y := 42.2),"
+                                                  + "STRUCT_PACK(x := 43.3, y := 44.4),"
+                                                  + "STRUCT_PACK(x := 45.5, y := 46.6),"
+                                                  + "STRUCT_PACK(x := 47.7, y := 48.8)"
+                                                  + "]]::POLYGON_2D")) {
+                rs.next();
+                Array array = rs.getArray(1);
+                Object[] arrOuterObj = (Object[]) array.getArray();
+                Array arrOuter = (Array) arrOuterObj[0];
+                Object[] arr = (Object[]) arrOuter.getArray();
+                DuckDBStruct struct1 = (DuckDBStruct) arr[0];
+                assertEquals(41.1d, struct1.getMap().get("x"));
+                assertEquals(42.2d, struct1.getMap().get("y"));
+                DuckDBStruct struct2 = (DuckDBStruct) arr[1];
+                assertEquals(43.3d, struct2.getMap().get("x"));
+                assertEquals(44.4d, struct2.getMap().get("y"));
+                DuckDBStruct struct3 = (DuckDBStruct) arr[2];
+                assertEquals(45.5d, struct3.getMap().get("x"));
+                assertEquals(46.6d, struct3.getMap().get("y"));
+                DuckDBStruct struct4 = (DuckDBStruct) arr[3];
+                assertEquals(47.7d, struct4.getMap().get("x"));
+                assertEquals(48.8d, struct4.getMap().get("y"));
+            }
+
+            // POLYGON_2D parameter
+            try (PreparedStatement ps = conn.prepareStatement("SELECT ?::POLYGON_2D")) {
+                Struct point1 = conn.createStruct("POINT_2D", new Object[] {41.1d, 42.2d});
+                Struct point2 = conn.createStruct("POINT_2D", new Object[] {43.3d, 44.4d});
+                Struct point3 = conn.createStruct("POINT_2D", new Object[] {45.5d, 46.6d});
+                Struct point4 = conn.createStruct("POINT_2D", new Object[] {47.7d, 48.8d});
+                Array arrWrapper = conn.createArrayOf("POINT_2D", new Object[] {point1, point2, point3, point4});
+                Array param = conn.createArrayOf("POINT_2D[]", new Object[] {arrWrapper});
+                ps.setObject(1, param);
+                try (ResultSet rs = ps.executeQuery()) {
+                    rs.next();
+                    Array array = rs.getArray(1);
+                    Object[] arrOuterObj = (Object[]) array.getArray();
+                    Array arrOuter = (Array) arrOuterObj[0];
+                    Object[] arr = (Object[]) arrOuter.getArray();
+                    DuckDBStruct struct1 = (DuckDBStruct) arr[0];
+                    assertEquals(41.1d, struct1.getMap().get("x"));
+                    assertEquals(42.2d, struct1.getMap().get("y"));
+                    DuckDBStruct struct2 = (DuckDBStruct) arr[1];
+                    assertEquals(43.3d, struct2.getMap().get("x"));
+                    assertEquals(44.4d, struct2.getMap().get("y"));
+                    DuckDBStruct struct3 = (DuckDBStruct) arr[2];
+                    assertEquals(45.5d, struct3.getMap().get("x"));
+                    assertEquals(46.6d, struct3.getMap().get("y"));
+                    DuckDBStruct struct4 = (DuckDBStruct) arr[3];
+                    assertEquals(47.7d, struct4.getMap().get("x"));
+                    assertEquals(48.8d, struct4.getMap().get("y"));
+                }
+            }
+        }
+    }
+
+    public static void test_spatial_GEOMETRY() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate("INSTALL spatial");
+            stmt.executeUpdate("LOAD spatial");
+
+            byte[] geometryBytes =
+                new byte[] {0,   0,   0,   0,   0,   0,    0,  0,  0,    0,    0,    0,    1,    0,  0,  0,
+                            -51, -52, -52, -52, -52, -116, 68, 64, -102, -103, -103, -103, -103, 25, 69, 64};
+
+            // GEOMETRY literal
+            try (ResultSet rs = stmt.executeQuery("SELECT ST_GeomFromText('POINT(41.1 42.2)')")) {
+                rs.next();
+                Blob blob = rs.getBlob(1);
+                byte[] bytes = blob.getBytes(1, (int) blob.length());
+                List<Byte> list = new ArrayList<>();
+                for (byte b : bytes) {
+                    list.add(b);
+                }
+                List<Byte> expected = new ArrayList<>();
+                for (byte b : geometryBytes) {
+                    expected.add(b);
+                }
+                assertListsEqual(expected, list);
+            }
+
+            // GEOMETRY parameter
+            try (PreparedStatement ps = conn.prepareStatement("SELECT ?::POINT_2D::GEOMETRY")) {
+                Struct param = conn.createStruct("POINT_2D", new Object[] {41.1d, 42.2d});
+                ps.setObject(1, param);
+                try (ResultSet rs = ps.executeQuery()) {
+                    rs.next();
+                    Blob blob = rs.getBlob(1);
+                    byte[] bytes = blob.getBytes(1, (int) blob.length());
+                    List<Byte> list = new ArrayList<>();
+                    for (byte b : bytes) {
+                        list.add(b);
+                    }
+                    List<Byte> expected = new ArrayList<>();
+                    for (byte b : geometryBytes) {
+                        expected.add(b);
+                    }
+                    assertListsEqual(expected, list);
+                }
+            }
+        }
+    }
+
+    public static void test_spatial_WKB_BLOB() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate("INSTALL spatial");
+            stmt.executeUpdate("LOAD spatial");
+
+            byte[] wkbBytes = new byte[] {1,  1,  0,    0,    0,    -51,  -52,  -52, -52, -52, -116,
+                                          68, 64, -102, -103, -103, -103, -103, 25,  69,  64};
+
+            // WKB_BLOB literal
+            try (ResultSet rs = stmt.executeQuery("SELECT ST_AsWKB(ST_GeomFromText('POINT(41.1 42.2)'))")) {
+                rs.next();
+                Blob blob = rs.getBlob(1);
+                byte[] bytes = blob.getBytes(1, (int) blob.length());
+                List<Byte> list = new ArrayList<>();
+                for (byte b : bytes) {
+                    list.add(b);
+                }
+                List<Byte> expected = new ArrayList<>();
+                for (byte b : wkbBytes) {
+                    expected.add(b);
+                }
+                assertListsEqual(expected, list);
+            }
+
+            // WKB_BLOB parameter - not implemented
+        }
+    }
+}

--- a/src/test/java/org/duckdb/test/Assertions.java
+++ b/src/test/java/org/duckdb/test/Assertions.java
@@ -1,6 +1,8 @@
 package org.duckdb.test;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.ListIterator;
 import java.util.Objects;
 import java.util.function.Function;
 import org.duckdb.test.Thrower;
@@ -40,6 +42,21 @@ public class Assertions {
 
     public static void assertEquals(byte[] actual, byte[] expected, String message) throws Exception {
         assertTrue(Arrays.equals(actual, expected), message);
+    }
+
+    public static <T> void assertListsEqual(List<T> actual, List<T> expected) throws Exception {
+        assertListsEqual(actual, expected, "");
+    }
+
+    public static <T> void assertListsEqual(List<T> actual, List<T> expected, String label) throws Exception {
+        assertEquals(actual.size(), expected.size());
+
+        ListIterator<T> itera = actual.listIterator();
+        ListIterator<T> itere = expected.listIterator();
+
+        while (itera.hasNext()) {
+            assertEquals(itera.next(), itere.next(), label);
+        }
     }
 
     public static void assertNotNull(Object a) throws Exception {

--- a/src/test/java/org/duckdb/test/Runner.java
+++ b/src/test/java/org/duckdb/test/Runner.java
@@ -27,14 +27,22 @@ public class Runner {
                                    .collect(Collectors.toList());
 
         String specific_test = null;
+        boolean quick_run = false;
         if (args.length >= 1) {
-            specific_test = args[0];
+            if ("quick".equals(args[0])) {
+                quick_run = true;
+            } else {
+                specific_test = args[0];
+            }
         }
 
         boolean anySucceeded = false;
         boolean anyFailed = false;
         for (Method m : methods) {
             if (m.getName().startsWith("test_")) {
+                if (quick_run && m.getName().startsWith("test_lots_")) {
+                    continue;
+                }
                 if (specific_test != null && !m.getName().contains(specific_test)) {
                     continue;
                 }


### PR DESCRIPTION
This PR changes the handling of extension types. Instead of treating
all custom types (detected by having an alias) as `VARCHAR`, it ignores
type alias and uses underlying logical type.

This allows to work with the following types from the spatial
extension using default JDBC types `java.sql.Struct`, `java.sql.Array`,
and `java.sql.Blob`:

 - `POINT_2D`: as `STRUCT{x: DOUBLE, y: DOUBLE}`
 - `POINT_3D`: as `STRUCT{x: DOUBLE, y: DOUBLE, z: DOUBLE}`
 - `POINT_4D`: as `STRUCT{x: DOUBLE, y: DOUBLE, z: DOUBLE, m: DOUBLE}`
 - `LINESTRING_2D`: as `LIST[STRUCT{x: DOUBLE, y: DOUBLE}]`
 - `POLYGON_2D`: as `LIST[LIST[STRUCT{x: DOUBLE, y: DOUBLE}]]`
 - `BOX_2D`: as `STRUCT{min_x: DOUBLE, max_x: DOUBLE, min_y: DOUBLE, max_y: DOUBLE}`
 - `BOX_2DF`: as `STRUCT{min_x: FLOAT, max_x: FLOAT, min_y: FLOAT, max_y: FLOAT}`
 - `GEOMETRY`: as `BLOB`
 - `WKB_BLOB`: as `BLOB`

Special handling is left only for `JSON` type because it is mapped to
driver-specific `JsonNode` class.

Testing: existing test for extnsion types is adjusted to use
`java.sql.Struct` and `java.sql.Blob`. New test is added to cover all
spatial types in bind parameters and in result set, minor enhancements
are added to tests runner.

Fixes: https://github.com/duckdb/duckdb-java/issues/37

Edit: description updated