### PR TITLE
Close pending statements on connection close

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -439,7 +439,7 @@ set(DUCKDB_SRC_FILES
   src/duckdb/extension/json/json_serializer.cpp
   src/duckdb/ub_extension_json_json_functions.cpp)
 
-set(JEMACLLOC_SRC_FILES 
+set(JEMALLOC_SRC_FILES 
   src/duckdb/extension/jemalloc/jemalloc_extension.cpp
   src/duckdb/extension/jemalloc/jemalloc/src/jemalloc.c
   src/duckdb/extension/jemalloc/jemalloc/src/arena.c
@@ -553,7 +553,7 @@ add_jar(duckdb_jdbc_tests ${JAVA_TEST_FILES} INCLUDE_JARS duckdb_jdbc)
 if(MSVC)
   list(APPEND DUCKDB_SRC_FILES duckdb_java.def)
 else()
-  list(APPEND DUCKDB_SRC_FILES ${JEMACLLOC_SRC_FILES})
+  list(APPEND DUCKDB_SRC_FILES ${JEMALLOC_SRC_FILES})
 endif()
 
 add_library(duckdb_java SHARED

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -46,7 +46,7 @@ set(DUCKDB_DEFINITIONS
 set(DUCKDB_SRC_FILES 
   ${SOURCES})
 
-set(JEMACLLOC_SRC_FILES 
+set(JEMALLOC_SRC_FILES 
   ${JEMALLOC_SOURCES})
 
 
@@ -95,7 +95,7 @@ add_jar(duckdb_jdbc_tests ${JAVA_TEST_FILES} INCLUDE_JARS duckdb_jdbc)
 if(MSVC)
   list(APPEND DUCKDB_SRC_FILES duckdb_java.def)
 else()
-  list(APPEND DUCKDB_SRC_FILES ${JEMACLLOC_SRC_FILES})
+  list(APPEND DUCKDB_SRC_FILES ${JEMALLOC_SRC_FILES})
 endif()
 
 add_library(duckdb_java SHARED

--- a/src/jni/functions.cpp
+++ b/src/jni/functions.cpp
@@ -404,5 +404,6 @@ JNIEXPORT jstring JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1get_1profil
 		duckdb::ErrorData error(e);
 		ThrowJNI(env, error.Message().c_str());
 
+		return nullptr;
 	}
 }

--- a/src/jni/holders.hpp
+++ b/src/jni/holders.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "duckdb.hpp"
+
+#include <jni.h>
+
+/**
+ * Associates a duckdb::Connection with a duckdb::DuckDB. The DB may be shared amongst many ConnectionHolders, but the
+ * Connection is unique to this holder. Every Java DuckDBConnection has exactly 1 of these holders, and they are never
+ * shared. The holder is freed when the DuckDBConnection is closed. When the last holder sharing a DuckDB is freed, the
+ * DuckDB is released as well.
+ */
+struct ConnectionHolder {
+	const duckdb::shared_ptr<duckdb::DuckDB> db;
+	const duckdb::unique_ptr<duckdb::Connection> connection;
+
+	ConnectionHolder(duckdb::shared_ptr<duckdb::DuckDB> _db)
+	    : db(_db), connection(duckdb::make_uniq<duckdb::Connection>(*_db)) {
+	}
+};
+
+struct StatementHolder {
+	duckdb::unique_ptr<duckdb::PreparedStatement> stmt;
+};
+
+struct ResultHolder {
+	duckdb::unique_ptr<duckdb::QueryResult> res;
+	duckdb::unique_ptr<duckdb::DataChunk> chunk;
+};
+
+/**
+ * Throws a SQLException and returns nullptr if a valid Connection can't be retrieved from the buffer.
+ */
+inline duckdb::Connection *get_connection(JNIEnv *env, jobject conn_ref_buf) {
+	if (!conn_ref_buf) {
+		throw duckdb::ConnectionException("Invalid connection");
+	}
+	auto conn_holder = (ConnectionHolder *)env->GetDirectBufferAddress(conn_ref_buf);
+	if (!conn_holder) {
+		throw duckdb::ConnectionException("Invalid connection");
+	}
+	auto conn_ref = conn_holder->connection.get();
+	if (!conn_ref || !conn_ref->context) {
+		throw duckdb::ConnectionException("Invalid connection");
+	}
+
+	return conn_ref;
+}

--- a/src/main/java/org/duckdb/DuckDBAppender.java
+++ b/src/main/java/org/duckdb/DuckDBAppender.java
@@ -16,7 +16,7 @@ public class DuckDBAppender implements AutoCloseable {
             throw new SQLException("Invalid connection");
         }
         appender_ref = DuckDBNative.duckdb_jdbc_create_appender(
-            con.conn_ref, schemaName.getBytes(StandardCharsets.UTF_8), tableName.getBytes(StandardCharsets.UTF_8));
+            con.connRef, schemaName.getBytes(StandardCharsets.UTF_8), tableName.getBytes(StandardCharsets.UTF_8));
     }
 
     public void beginRow() throws SQLException {

--- a/src/main/java/org/duckdb/DuckDBDatabaseMetaData.java
+++ b/src/main/java/org/duckdb/DuckDBDatabaseMetaData.java
@@ -14,8 +14,6 @@ import java.sql.Types;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
-import javax.sql.rowset.CachedRowSet;
-import javax.sql.rowset.RowSetProvider;
 
 public class DuckDBDatabaseMetaData implements DatabaseMetaData {
 
@@ -173,74 +171,74 @@ public class DuckDBDatabaseMetaData implements DatabaseMetaData {
 
     @Override
     public String getSQLKeywords() throws SQLException {
-        Statement statement = conn.createStatement();
-        statement.closeOnCompletion();
-        ResultSet rs = statement.executeQuery("SELECT keyword_name FROM duckdb_keywords()");
-        StringBuilder sb = new StringBuilder();
-        while (rs.next()) {
-            sb.append(rs.getString(1));
-            sb.append(',');
+        try (Statement statement = conn.createStatement();
+             ResultSet rs = statement.executeQuery("SELECT keyword_name FROM duckdb_keywords()")) {
+            StringBuilder sb = new StringBuilder();
+            while (rs.next()) {
+                sb.append(rs.getString(1));
+                sb.append(',');
+            }
+            return sb.toString();
         }
-        return sb.toString();
     }
 
     @Override
     public String getNumericFunctions() throws SQLException {
-        Statement statement = conn.createStatement();
-        statement.closeOnCompletion();
-        ResultSet rs = statement.executeQuery("SELECT DISTINCT function_name FROM duckdb_functions() "
-                                              + "WHERE parameter_types[1] ='DECIMAL'"
-                                              + "OR parameter_types[1] ='DOUBLE'"
-                                              + "OR parameter_types[1] ='SMALLINT'"
-                                              + "OR parameter_types[1] = 'BIGINT'");
-        StringBuilder sb = new StringBuilder();
-        while (rs.next()) {
-            sb.append(rs.getString(1));
-            sb.append(',');
+        try (Statement statement = conn.createStatement();
+             ResultSet rs = statement.executeQuery("SELECT DISTINCT function_name FROM duckdb_functions() "
+                                                   + "WHERE parameter_types[1] ='DECIMAL'"
+                                                   + "OR parameter_types[1] ='DOUBLE'"
+                                                   + "OR parameter_types[1] ='SMALLINT'"
+                                                   + "OR parameter_types[1] = 'BIGINT'")) {
+            StringBuilder sb = new StringBuilder();
+            while (rs.next()) {
+                sb.append(rs.getString(1));
+                sb.append(',');
+            }
+            return sb.toString();
         }
-        return sb.toString();
     }
 
     @Override
     public String getStringFunctions() throws SQLException {
-        Statement statement = conn.createStatement();
-        statement.closeOnCompletion();
-        ResultSet rs = statement.executeQuery(
-            "SELECT DISTINCT function_name FROM duckdb_functions() WHERE parameter_types[1] = 'VARCHAR'");
-        StringBuilder sb = new StringBuilder();
-        while (rs.next()) {
-            sb.append(rs.getString(1));
-            sb.append(',');
+        try (Statement statement = conn.createStatement();
+             ResultSet rs = statement.executeQuery(
+                 "SELECT DISTINCT function_name FROM duckdb_functions() WHERE parameter_types[1] = 'VARCHAR'")) {
+            StringBuilder sb = new StringBuilder();
+            while (rs.next()) {
+                sb.append(rs.getString(1));
+                sb.append(',');
+            }
+            return sb.toString();
         }
-        return sb.toString();
     }
 
     @Override
     public String getSystemFunctions() throws SQLException {
-        Statement statement = conn.createStatement();
-        statement.closeOnCompletion();
-        ResultSet rs = statement.executeQuery(
-            "SELECT DISTINCT function_name FROM duckdb_functions() WHERE length(parameter_types) = 0");
-        StringBuilder sb = new StringBuilder();
-        while (rs.next()) {
-            sb.append(rs.getString(1));
-            sb.append(',');
+        try (Statement statement = conn.createStatement();
+             ResultSet rs = statement.executeQuery(
+                 "SELECT DISTINCT function_name FROM duckdb_functions() WHERE length(parameter_types) = 0")) {
+            StringBuilder sb = new StringBuilder();
+            while (rs.next()) {
+                sb.append(rs.getString(1));
+                sb.append(',');
+            }
+            return sb.toString();
         }
-        return sb.toString();
     }
 
     @Override
     public String getTimeDateFunctions() throws SQLException {
-        Statement statement = conn.createStatement();
-        statement.closeOnCompletion();
-        ResultSet rs = statement.executeQuery(
-            "SELECT DISTINCT function_name FROM duckdb_functions() WHERE parameter_types[1] LIKE 'TIME%'");
-        StringBuilder sb = new StringBuilder();
-        while (rs.next()) {
-            sb.append(rs.getString(1));
-            sb.append(',');
+        try (Statement statement = conn.createStatement();
+             ResultSet rs = statement.executeQuery(
+                 "SELECT DISTINCT function_name FROM duckdb_functions() WHERE parameter_types[1] LIKE 'TIME%'")) {
+            StringBuilder sb = new StringBuilder();
+            while (rs.next()) {
+                sb.append(rs.getString(1));
+                sb.append(',');
+            }
+            return sb.toString();
         }
-        return sb.toString();
     }
 
     @Override

--- a/src/main/java/org/duckdb/DuckDBNative.java
+++ b/src/main/java/org/duckdb/DuckDBNative.java
@@ -13,7 +13,7 @@ import java.nio.file.StandardCopyOption;
 import java.sql.SQLException;
 import java.util.Properties;
 
-class DuckDBNative {
+final class DuckDBNative {
     static {
         try {
             String os_name = "";
@@ -70,108 +70,92 @@ class DuckDBNative {
      */
 
     // results ConnectionHolder reference object
-    protected static native ByteBuffer duckdb_jdbc_startup(byte[] path, boolean read_only, Properties props)
-        throws SQLException;
+    static native ByteBuffer duckdb_jdbc_startup(byte[] path, boolean read_only, Properties props) throws SQLException;
 
     // returns conn_ref connection reference object
-    protected static native ByteBuffer duckdb_jdbc_connect(ByteBuffer db_ref) throws SQLException;
+    static native ByteBuffer duckdb_jdbc_connect(ByteBuffer db_ref) throws SQLException;
 
-    protected static native void duckdb_jdbc_set_auto_commit(ByteBuffer conn_ref, boolean auto_commit)
-        throws SQLException;
+    static native void duckdb_jdbc_set_auto_commit(ByteBuffer conn_ref, boolean auto_commit) throws SQLException;
 
-    protected static native boolean duckdb_jdbc_get_auto_commit(ByteBuffer conn_ref) throws SQLException;
+    static native boolean duckdb_jdbc_get_auto_commit(ByteBuffer conn_ref) throws SQLException;
 
-    protected static native void duckdb_jdbc_disconnect(ByteBuffer conn_ref);
+    static native void duckdb_jdbc_disconnect(ByteBuffer conn_ref);
 
-    protected static native void duckdb_jdbc_set_schema(ByteBuffer conn_ref, String schema);
+    static native void duckdb_jdbc_set_schema(ByteBuffer conn_ref, String schema);
 
-    protected static native void duckdb_jdbc_set_catalog(ByteBuffer conn_ref, String catalog);
+    static native void duckdb_jdbc_set_catalog(ByteBuffer conn_ref, String catalog);
 
-    protected static native String duckdb_jdbc_get_schema(ByteBuffer conn_ref);
+    static native String duckdb_jdbc_get_schema(ByteBuffer conn_ref);
 
-    protected static native String duckdb_jdbc_get_catalog(ByteBuffer conn_ref);
+    static native String duckdb_jdbc_get_catalog(ByteBuffer conn_ref);
 
     // returns stmt_ref result reference object
-    protected static native ByteBuffer duckdb_jdbc_prepare(ByteBuffer conn_ref, byte[] query) throws SQLException;
+    static native ByteBuffer duckdb_jdbc_prepare(ByteBuffer conn_ref, byte[] query) throws SQLException;
 
-    protected static native void duckdb_jdbc_release(ByteBuffer stmt_ref);
+    static native void duckdb_jdbc_release(ByteBuffer stmt_ref);
 
-    protected static native DuckDBResultSetMetaData duckdb_jdbc_query_result_meta(ByteBuffer result_ref)
-        throws SQLException;
+    static native DuckDBResultSetMetaData duckdb_jdbc_query_result_meta(ByteBuffer result_ref) throws SQLException;
 
-    protected static native DuckDBResultSetMetaData duckdb_jdbc_prepared_statement_meta(ByteBuffer stmt_ref)
-        throws SQLException;
+    static native DuckDBResultSetMetaData duckdb_jdbc_prepared_statement_meta(ByteBuffer stmt_ref) throws SQLException;
 
     // returns res_ref result reference object
-    protected static native ByteBuffer duckdb_jdbc_execute(ByteBuffer stmt_ref, Object[] params) throws SQLException;
+    static native ByteBuffer duckdb_jdbc_execute(ByteBuffer stmt_ref, Object[] params) throws SQLException;
 
-    protected static native void duckdb_jdbc_free_result(ByteBuffer res_ref);
+    static native void duckdb_jdbc_free_result(ByteBuffer res_ref);
 
-    protected static native DuckDBVector[] duckdb_jdbc_fetch(ByteBuffer res_ref, ByteBuffer conn_ref)
+    static native DuckDBVector[] duckdb_jdbc_fetch(ByteBuffer res_ref, ByteBuffer conn_ref) throws SQLException;
+
+    static native int duckdb_jdbc_fetch_size();
+
+    static native long duckdb_jdbc_arrow_stream(ByteBuffer res_ref, long batch_size);
+
+    static native void duckdb_jdbc_arrow_register(ByteBuffer conn_ref, long arrow_array_stream_pointer, byte[] name);
+
+    static native ByteBuffer duckdb_jdbc_create_appender(ByteBuffer conn_ref, byte[] schema_name, byte[] table_name)
         throws SQLException;
 
-    protected static native int duckdb_jdbc_fetch_size();
+    static native void duckdb_jdbc_appender_begin_row(ByteBuffer appender_ref) throws SQLException;
 
-    protected static native long duckdb_jdbc_arrow_stream(ByteBuffer res_ref, long batch_size);
+    static native void duckdb_jdbc_appender_end_row(ByteBuffer appender_ref) throws SQLException;
 
-    protected static native void duckdb_jdbc_arrow_register(ByteBuffer conn_ref, long arrow_array_stream_pointer,
-                                                            byte[] name);
+    static native void duckdb_jdbc_appender_flush(ByteBuffer appender_ref) throws SQLException;
 
-    protected static native ByteBuffer duckdb_jdbc_create_appender(ByteBuffer conn_ref, byte[] schema_name,
-                                                                   byte[] table_name) throws SQLException;
+    static native void duckdb_jdbc_interrupt(ByteBuffer conn_ref);
 
-    protected static native void duckdb_jdbc_appender_begin_row(ByteBuffer appender_ref) throws SQLException;
+    static native void duckdb_jdbc_appender_close(ByteBuffer appender_ref) throws SQLException;
 
-    protected static native void duckdb_jdbc_appender_end_row(ByteBuffer appender_ref) throws SQLException;
+    static native void duckdb_jdbc_appender_append_boolean(ByteBuffer appender_ref, boolean value) throws SQLException;
 
-    protected static native void duckdb_jdbc_appender_flush(ByteBuffer appender_ref) throws SQLException;
+    static native void duckdb_jdbc_appender_append_byte(ByteBuffer appender_ref, byte value) throws SQLException;
 
-    protected static native void duckdb_jdbc_interrupt(ByteBuffer conn_ref);
+    static native void duckdb_jdbc_appender_append_short(ByteBuffer appender_ref, short value) throws SQLException;
 
-    protected static native void duckdb_jdbc_appender_close(ByteBuffer appender_ref) throws SQLException;
+    static native void duckdb_jdbc_appender_append_int(ByteBuffer appender_ref, int value) throws SQLException;
 
-    protected static native void duckdb_jdbc_appender_append_boolean(ByteBuffer appender_ref, boolean value)
+    static native void duckdb_jdbc_appender_append_long(ByteBuffer appender_ref, long value) throws SQLException;
+
+    static native void duckdb_jdbc_appender_append_float(ByteBuffer appender_ref, float value) throws SQLException;
+
+    static native void duckdb_jdbc_appender_append_double(ByteBuffer appender_ref, double value) throws SQLException;
+
+    static native void duckdb_jdbc_appender_append_string(ByteBuffer appender_ref, byte[] value) throws SQLException;
+
+    static native void duckdb_jdbc_appender_append_bytes(ByteBuffer appender_ref, byte[] value) throws SQLException;
+
+    static native void duckdb_jdbc_appender_append_timestamp(ByteBuffer appender_ref, long value) throws SQLException;
+
+    static native void duckdb_jdbc_appender_append_decimal(ByteBuffer appender_ref, BigDecimal value)
         throws SQLException;
 
-    protected static native void duckdb_jdbc_appender_append_byte(ByteBuffer appender_ref, byte value)
-        throws SQLException;
+    static native void duckdb_jdbc_appender_append_null(ByteBuffer appender_ref) throws SQLException;
 
-    protected static native void duckdb_jdbc_appender_append_short(ByteBuffer appender_ref, short value)
-        throws SQLException;
-
-    protected static native void duckdb_jdbc_appender_append_int(ByteBuffer appender_ref, int value)
-        throws SQLException;
-
-    protected static native void duckdb_jdbc_appender_append_long(ByteBuffer appender_ref, long value)
-        throws SQLException;
-
-    protected static native void duckdb_jdbc_appender_append_float(ByteBuffer appender_ref, float value)
-        throws SQLException;
-
-    protected static native void duckdb_jdbc_appender_append_double(ByteBuffer appender_ref, double value)
-        throws SQLException;
-
-    protected static native void duckdb_jdbc_appender_append_string(ByteBuffer appender_ref, byte[] value)
-        throws SQLException;
-
-    protected static native void duckdb_jdbc_appender_append_bytes(ByteBuffer appender_ref, byte[] value)
-        throws SQLException;
-
-    protected static native void duckdb_jdbc_appender_append_timestamp(ByteBuffer appender_ref, long value)
-        throws SQLException;
-
-    protected static native void duckdb_jdbc_appender_append_decimal(ByteBuffer appender_ref, BigDecimal value)
-        throws SQLException;
-
-    protected static native void duckdb_jdbc_appender_append_null(ByteBuffer appender_ref) throws SQLException;
-
-    protected static native void duckdb_jdbc_create_extension_type(ByteBuffer conn_ref) throws SQLException;
+    static native void duckdb_jdbc_create_extension_type(ByteBuffer conn_ref) throws SQLException;
 
     protected static native String duckdb_jdbc_get_profiling_information(ByteBuffer conn_ref,
                                                                          ProfilerPrintFormat format)
         throws SQLException;
 
     public static void duckdb_jdbc_create_extension_type(DuckDBConnection conn) throws SQLException {
-        duckdb_jdbc_create_extension_type(conn.conn_ref);
+        duckdb_jdbc_create_extension_type(conn.connRef);
     }
 }

--- a/src/test/java/org/duckdb/TestClosure.java
+++ b/src/test/java/org/duckdb/TestClosure.java
@@ -1,0 +1,223 @@
+package org.duckdb;
+
+import static org.duckdb.TestDuckDBJDBC.JDBC_URL;
+import static org.duckdb.test.Assertions.*;
+
+import java.io.File;
+import java.sql.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+public class TestClosure {
+
+    // https://github.com/duckdb/duckdb-java/issues/101
+    public static void test_unclosed_statement_does_not_hang() throws Exception {
+        String dbName = "test_issue_101.db";
+        String url = JDBC_URL + dbName;
+        Connection conn = DriverManager.getConnection(url);
+        Statement stmt = conn.createStatement();
+        stmt.execute("select 42");
+        // statement not closed explicitly
+        conn.close();
+        assertTrue(stmt.isClosed());
+        Connection connOther = DriverManager.getConnection(url);
+        connOther.close();
+        assertTrue(new File(dbName).delete());
+    }
+
+    public static void test_result_set_auto_closed() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
+            Statement stmt = conn.createStatement();
+            ResultSet rs1 = stmt.executeQuery("select 42");
+            ResultSet rs2 = stmt.executeQuery("select 43");
+            assertTrue(rs1.isClosed());
+            stmt.close();
+            assertTrue(rs2.isClosed());
+        }
+    }
+
+    public static void test_statements_auto_closed_on_conn_close() throws Exception {
+        Connection conn = DriverManager.getConnection(JDBC_URL);
+        Statement stmt1 = conn.createStatement();
+        stmt1.execute("select 42");
+        PreparedStatement stmt2 = conn.prepareStatement("select 43");
+        stmt2.execute();
+        Statement stmt3 = conn.createStatement();
+        stmt3.execute("select 44");
+        stmt3.close();
+        conn.close();
+        assertTrue(stmt1.isClosed());
+        assertTrue(stmt2.isClosed());
+    }
+
+    public static void test_results_auto_closed_on_conn_close() throws Exception {
+        Connection conn = DriverManager.getConnection(JDBC_URL);
+        Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery("select 42");
+        rs.next();
+        conn.close();
+        assertTrue(rs.isClosed());
+        assertTrue(stmt.isClosed());
+    }
+
+    public static void test_statement_auto_closed_on_completion() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
+            Statement stmt = conn.createStatement();
+            stmt.closeOnCompletion();
+            assertTrue(stmt.isCloseOnCompletion());
+            try (ResultSet rs = stmt.executeQuery("select 42")) {
+                rs.next();
+            }
+            assertTrue(stmt.isClosed());
+        }
+    }
+
+    public static void test_long_query_conn_close() throws Exception {
+        Connection conn = DriverManager.getConnection(JDBC_URL);
+        Statement stmt = conn.createStatement();
+        stmt.execute("DROP TABLE IF EXISTS test_fib1");
+        stmt.execute("CREATE TABLE test_fib1(i bigint, p double, f double)");
+        stmt.execute("INSERT INTO test_fib1 values(1, 0, 1)");
+        long start = System.currentTimeMillis();
+        Thread th = new Thread(() -> {
+            try {
+                Thread.sleep(1000);
+                conn.close();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+        th.start();
+        assertThrows(
+            ()
+                -> stmt.executeQuery(
+                    "WITH RECURSIVE cte AS ("
+                    +
+                    "SELECT * from test_fib1 UNION ALL SELECT cte.i + 1, cte.f, cte.p + cte.f from cte WHERE cte.i < 150000) "
+                    + "SELECT avg(f) FROM cte"),
+            SQLException.class);
+        th.join();
+        long elapsed = System.currentTimeMillis() - start;
+        assertTrue(elapsed < 2000);
+        assertTrue(stmt.isClosed());
+        assertTrue(conn.isClosed());
+    }
+
+    public static void test_long_query_stmt_close() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
+            Statement stmt = conn.createStatement();
+            stmt.execute("DROP TABLE IF EXISTS test_fib1");
+            stmt.execute("CREATE TABLE test_fib1(i bigint, p double, f double)");
+            stmt.execute("INSERT INTO test_fib1 values(1, 0, 1)");
+            long start = System.currentTimeMillis();
+            Thread th = new Thread(() -> {
+                try {
+                    Thread.sleep(1000);
+                    stmt.cancel();
+                    stmt.close();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            });
+            th.start();
+            assertThrows(
+                ()
+                    -> stmt.executeQuery(
+                        "WITH RECURSIVE cte AS ("
+                        +
+                        "SELECT * from test_fib1 UNION ALL SELECT cte.i + 1, cte.f, cte.p + cte.f from cte WHERE cte.i < 150000) "
+                        + "SELECT avg(f) FROM cte"),
+                SQLException.class);
+            th.join();
+            long elapsed = System.currentTimeMillis() - start;
+            assertTrue(elapsed < 2000);
+            assertTrue(stmt.isClosed());
+            assertFalse(conn.isClosed());
+        }
+    }
+
+    public static void test_conn_close_no_crash() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        for (int i = 0; i < 1 << 7; i++) {
+            Connection conn = DriverManager.getConnection(JDBC_URL);
+            Statement stmt = conn.createStatement();
+            Future<?> future = executor.submit(() -> {
+                try {
+                    conn.close();
+                } catch (SQLException e) {
+                    fail();
+                }
+            });
+            try {
+                stmt.executeQuery("select 42");
+            } catch (SQLException e) {
+            }
+            future.get();
+        }
+    }
+
+    public static void test_stmt_close_no_crash() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
+            for (int i = 0; i < 1 << 10; i++) {
+                Statement stmt = conn.createStatement();
+                Future<?> future = executor.submit(() -> {
+                    try {
+                        stmt.close();
+                    } catch (SQLException e) {
+                        fail();
+                    }
+                });
+                try {
+                    stmt.executeQuery("select 42");
+                } catch (SQLException e) {
+                }
+                future.get();
+            }
+        }
+    }
+
+    public static void test_results_close_no_crash() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement()) {
+            for (int i = 0; i < 1 << 12; i++) {
+                ResultSet rs = stmt.executeQuery("select 42");
+                Future<?> future = executor.submit(() -> {
+                    try {
+                        rs.close();
+                    } catch (SQLException e) {
+                        fail();
+                    }
+                });
+                try {
+                    rs.next();
+                } catch (SQLException e) {
+                }
+                future.get();
+            }
+        }
+    }
+
+    public static void test_results_close_prepared_stmt_no_crash() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try (Connection conn = DriverManager.getConnection(JDBC_URL);
+             PreparedStatement stmt = conn.prepareStatement("select 42")) {
+            for (int i = 0; i < 1 << 12; i++) {
+                ResultSet rs = stmt.executeQuery();
+                Future<?> future = executor.submit(() -> {
+                    try {
+                        rs.close();
+                    } catch (SQLException e) {
+                        fail();
+                    }
+                });
+                try {
+                    rs.next();
+                } catch (SQLException e) {
+                }
+                future.get();
+            }
+        }
+    }
+}

--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -3085,7 +3085,7 @@ public class TestDuckDBJDBC {
             conn.getSchema();
             fail();
         } catch (SQLException e) {
-            assertEquals(e.getMessage(), "Connection Error: Invalid connection");
+            assertEquals(e.getMessage(), "Connection was closed");
         }
     }
 
@@ -4895,7 +4895,7 @@ public class TestDuckDBJDBC {
         } else {
             // extension installation fails on CI, Spatial test is temporary disabled
             statusCode = runTests(args, TestDuckDBJDBC.class, TestExtensionTypes.class /*, TestSpatial.class */,
-                                  TestParameterMetadata.class);
+                                  TestParameterMetadata.class, TestClosure.class);
         }
         System.exit(statusCode);
     }

--- a/src/test/java/org/duckdb/test/Assertions.java
+++ b/src/test/java/org/duckdb/test/Assertions.java
@@ -71,12 +71,12 @@ public class Assertions {
         assertTrue(Math.abs(a - b) < epsilon);
     }
 
-    public static void fail() throws Exception {
+    public static void fail() {
         fail(null);
     }
 
-    public static void fail(String s) throws Exception {
-        throw new Exception(s);
+    public static void fail(String s) {
+        throw new RuntimeException(s);
     }
 
     public static <T extends Throwable> String assertThrows(Thrower thrower, Class<T> exception) throws Exception {


### PR DESCRIPTION
This is a version 3 of this PR that attempts to safely close pending
statements when the connection is closed. In it all tracking and
locking logic is moved from C++ to Java:

 - `Connection`, `Statement` and `ResultSet` instances use their own
 locks; the check that corresponding reference is still alive is
 performed before every native call after obtaining the lock.
 - `Statement` lock is held during the query execution, note, this lock
 is NOT requied to call `statement#cancel()` because this operation is
 implemented on a `Connection` level.
 - When a `Connection` is being closed, pending query is cancelled
 first, and then all active statements are closed in a reverse creation
 order.

Note, thread safety for Appender and Arrow interfaces is going to be
addressed in subsequent PRs.

Testing: new tests added for various sequential and concurrent closure
scenarios.

Fixes: https://github.com/duckdb/duckdb-java/issues/101

Edit: description is updated to match updated impl.