### PR TITLE
Retain client config on connection duplication

### DIFF
--- a/src/jni/duckdb_java.cpp
+++ b/src/jni/duckdb_java.cpp
@@ -107,7 +107,9 @@ jobject _duckdb_jdbc_startup(JNIEnv *env, jclass, jbyteArray database_j, jboolea
 
 jobject _duckdb_jdbc_connect(JNIEnv *env, jclass, jobject conn_ref_buf) {
 	auto conn_ref = (ConnectionHolder *)env->GetDirectBufferAddress(conn_ref_buf);
+	auto config = ClientConfig::GetConfig(*conn_ref->connection->context);
 	auto conn = new ConnectionHolder(conn_ref->db);
+	conn->connection->context->config = config;
 	return env->NewDirectByteBuffer(conn, 0);
 }
 

--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -4798,6 +4798,23 @@ public class TestDuckDBJDBC {
         }
     }
 
+    public static void test_client_config_retained_on_dup() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
+            try (Statement stmt1 = conn.createStatement()) {
+                stmt1.execute("set home_directory='test1'");
+                try (ResultSet rs = stmt1.executeQuery("select current_setting('home_directory')")) {
+                    rs.next();
+                    assertEquals(rs.getString(1), "test1");
+                }
+            }
+            try (Connection dup = ((DuckDBConnection) conn).duplicate(); Statement stmt2 = dup.createStatement();
+                 ResultSet rs = stmt2.executeQuery("select current_setting('home_directory')")) {
+                rs.next();
+                assertEquals(rs.getString(1), "test1");
+            }
+        }
+    }
+
     public static void main(String[] args) throws Exception {
         System.exit(runTests(args, TestDuckDBJDBC.class, TestExtensionTypes.class));
     }


### PR DESCRIPTION
This change copies `ClientConfig` to a new connection on `duplicate()` call.

Testing: new test added that checks that `home_directory` value is retained in a duplicated connection.

Fixes: #148