### PR TITLE
add types.cpp to jni build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -560,6 +560,7 @@ add_library(duckdb_java SHARED
   src/jni/duckdb_java.cpp
   src/jni/functions.cpp
   src/jni/refs.cpp
+  src/jni/types.cpp
   src/jni/util.cpp
   ${DUCKDB_SRC_FILES})
 


### PR DESCRIPTION
when building on alpine (using its toolchain), without this file being explicitly listed, the resulting build fails with symbol errors in the linked .so.    adding this file explicitly to the build resolves them.