### PR TITLE
Allow to use empty typeMap on Connection

### DIFF
--- a/src/main/java/org/duckdb/DuckDBConnection.java
+++ b/src/main/java/org/duckdb/DuckDBConnection.java
@@ -20,6 +20,7 @@ import java.sql.SQLXML;
 import java.sql.Savepoint;
 import java.sql.Statement;
 import java.sql.Struct;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Executor;
@@ -257,10 +258,22 @@ public final class DuckDBConnection implements java.sql.Connection {
     }
 
     public Map<String, Class<?>> getTypeMap() throws SQLException {
-        throw new SQLFeatureNotSupportedException("getTypeMap");
+        if (isClosed()) {
+            throw new SQLException("Connection was closed");
+        }
+        return new HashMap<>();
     }
 
     public void setTypeMap(Map<String, Class<?>> map) throws SQLException {
+        if (isClosed()) {
+            throw new SQLException("Connection was closed");
+        }
+        if (map != null && (map instanceof java.util.HashMap)) {
+            // we return an empty Hash map if the user gives this back make sure we accept it.
+            if (map.isEmpty()) {
+                return;
+            }
+        }
         throw new SQLFeatureNotSupportedException("setTypeMap");
     }
 

--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -4793,6 +4793,19 @@ public class TestDuckDBJDBC {
         }
     }
 
+    public static void test_empty_typemap_allowed() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
+            Map<String, Class<?>> defaultMap = conn.getTypeMap();
+            assertEquals(defaultMap.size(), 0);
+            // check empty not throws
+            conn.setTypeMap(new HashMap<>());
+            // check custom map throws
+            Map<String, Class<?>> customMap = new HashMap<>();
+            customMap.put("foo", TestDuckDBJDBC.class);
+            assertThrows(() -> { conn.setTypeMap(customMap); }, SQLException.class);
+        }
+    }
+
     public static void main(String[] args) throws Exception {
         String arg1 = args.length > 0 ? args[0] : "";
         final int statusCode;


### PR DESCRIPTION
[Connection#getTypeMap()](https://docs.oracle.com/javase/8/docs/api/java/sql/Connection.html#getTypeMap--) and [setTypeMap()](https://docs.oracle.com/javase/8/docs/api/java/sql/Connection.html#setTypeMap-java.util.Map-) are two legacy methods that were added to Java in 1998 to support mapping composite DB fields to custom Java classes. With widespread use or object-relational mapping libraries (like Hibernate) these method remain virtually unused in Java applications. Still these method may be called by some tools, for example, when doing DB schema introspection.

Looking how these methods work in other JDBC drivers, we can see that in Postgres' `pgjdbc` the type map is accepted, but [not used for actual field mapping](https://github.com/pgjdbc/pgjdbc/blob/156d724e1d95052b41a19fb568b2f81919ae2197/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java#L733). And in SQL Server's `mssql-jdbc` [only empty type map is accepted](https://github.com/microsoft/mssql-jdbc/blob/13c5ddcb92239cc90d776eb143f65e7a247307f1/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerConnection.java#L5379) and empty type map is always returned.

It is proposed to follow SQL Server's approach to not throw on `getTypeMap()` and to allow empty map input in `setTypeMap()`.

Note: CMake change is unrelated, it is added to unbreak CI builds before #178 fix (or its variation from other PRs) is merged.

Testing: new test added that checks that empty type map is allowed.

Fixes: #150