### PR TITLE
Ignore path option passed by Spark

### DIFF
--- a/src/main/java/org/duckdb/DuckDBDriver.java
+++ b/src/main/java/org/duckdb/DuckDBDriver.java
@@ -38,6 +38,13 @@ public class DuckDBDriver implements java.sql.Driver {
             read_only = prop_clean.equals("1") || prop_clean.equals("true") || prop_clean.equals("yes");
         }
         info.put("duckdb_api", "jdbc");
+
+        // Apache Spark passes this option when SELECT on a JDBC DataSource
+        // table is performed. It is the internal Spark option and is likely
+        // passed by mistake, so we need to ignore it to allow the connection
+        // to be established.
+        info.remove("path");
+
         return DuckDBConnection.newConnection(url, read_only, info);
     }
 

--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -4869,6 +4869,13 @@ public class TestDuckDBJDBC {
         }
     }
 
+    public static void test_spark_path_option_ignored() throws Exception {
+        Properties config = new Properties();
+        config.put("path", "path/to/spark/catalog/dir");
+        Connection conn = DriverManager.getConnection(JDBC_URL, config);
+        conn.close();
+    }
+
     public static void main(String[] args) throws Exception {
         String arg1 = args.length > 0 ? args[0] : "";
         final int statusCode;


### PR DESCRIPTION
Apache Spark passes the `path` option when a SELECT on a JDBC DataSource table is performed. It is the internal Spark option and is likely passed by mistake, so we need to ignore it to allow the connection to be established.

Testing: new test added that checks that the `path` option is ignored.

Fixes: #55