### PR TITLE
Make ResultSet getters case insensitive

### DIFF
--- a/src/main/java/org/duckdb/DuckDBResultSet.java
+++ b/src/main/java/org/duckdb/DuckDBResultSet.java
@@ -308,7 +308,7 @@ public class DuckDBResultSet implements ResultSet {
             throw new SQLException("ResultSet was closed");
         }
         for (int col_idx = 0; col_idx < meta.column_count; col_idx++) {
-            if (meta.column_names[col_idx].contentEquals(columnLabel)) {
+            if (meta.column_names[col_idx].equalsIgnoreCase(columnLabel)) {
                 return col_idx + 1;
             }
         }


### PR DESCRIPTION
This change brings in the #43 PR with additional changes to the `Array` result set requested by the reviewer in #43.

For the `Array` result set the column names `INDEX` and `VALUE` are taken from the [implementation in Postgres' pgjdbc driver](https://github.com/pgjdbc/pgjdbc/blob/156d724e1d95052b41a19fb568b2f81919ae2197/pgjdbc/src/main/java/org/postgresql/jdbc/PgArray.java#L399).

Testing: test from #43 is included, test for `Array` result set is enhanced with additional checks.

Fixes: #40