### PR TITLE
Fix builds by adding missing types.cpp to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -561,6 +561,7 @@ add_library(duckdb_java SHARED
   src/jni/duckdb_java.cpp
   src/jni/functions.cpp
   src/jni/refs.cpp
+  src/jni/types.cpp
   src/jni/util.cpp
   ${DUCKDB_SRC_FILES})
 

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -103,6 +103,7 @@ add_library(duckdb_java SHARED
   src/jni/duckdb_java.cpp
   src/jni/functions.cpp
   src/jni/refs.cpp
+  src/jni/types.cpp
   src/jni/util.cpp
   ${DUCKDB_SRC_FILES})
 


### PR DESCRIPTION
In #168 `types.cpp` file was added to `CMakeLists.txt`, but, by mistake it was not added to `CMakeLists.txt.in` that is used to generate the `CMakeLists.txt` file on periodic engine sources import.

This change adds `types.cpp` to both `CMakeLists.txt.in` and `CMakeLists.txt` to fix the build.