### PR TITLE
Temporary disable compliance CI runs

### DIFF
--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -276,7 +276,10 @@ jobs:
   jdbc-compliance:
     name: JDBC Compliance
     runs-on: ubuntu-20.04
-    if: ${{ inputs.skip_tests != 'true' }}
+    # temporary disabled until jdbccts is fixed
+    # https://github.com/cwida/jdbccts/pull/1
+    if: ${{ false }}
+    #if: ${{ inputs.skip_tests != 'true' }}
     needs: java-linux-amd64
     container: quay.io/pypa/manylinux_2_28_x86_64
     env:


### PR DESCRIPTION
JDBC compliance test runs use the scripts from
https://github.com/cwida/jdbccts repo. CMake script in this repo became broken after the CMake 4.0 update on CI runners. It now breaks with the following message:

```
Compatibility with CMake < 3.5 has been removed from CMake.
```

There is an [ongoing activity](https://github.com/cwida/jdbccts/pull/1) to fix this in `jdbcct`, meanwhile this change temporary disables compliance CI runs until the fix is applied.