### PR TITLE
Re-enable compliance test runs on CI

### DIFF
--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -276,10 +276,7 @@ jobs:
   jdbc-compliance:
     name: JDBC Compliance
     runs-on: ubuntu-20.04
-    # temporary disabled until jdbccts is fixed
-    # https://github.com/cwida/jdbccts/pull/1
-    if: ${{ false }}
-    #if: ${{ inputs.skip_tests != 'true' }}
+    if: ${{ inputs.skip_tests != 'true' }}
     needs: java-linux-amd64
     container: quay.io/pypa/manylinux_2_28_x86_64
     env:


### PR DESCRIPTION
This reverts commit 9cbfad4be339663821671398ff6c23f8bcda5f05.

The https://github.com/cwida/jdbccts/pull/1 PR was just merged so compliance test should work again now.