### PR TITLE
Update Ubuntu image used for compiance runs

### DIFF
--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -275,7 +275,7 @@ jobs:
 
   jdbc-compliance:
     name: JDBC Compliance
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: ${{ inputs.skip_tests != 'true' }}
     needs: java-linux-amd64
     container: quay.io/pypa/manylinux_2_28_x86_64


### PR DESCRIPTION
This change attemts to use `ubuntu-latest` instead of `ubuntu-20.04` for JDBC compliance test suite run on GH actions.

Fixes: #191