### PR TITLE
Enable 4-part version number

### DIFF
--- a/scripts/jdbc_maven_deploy.py
+++ b/scripts/jdbc_maven_deploy.py
@@ -33,7 +33,7 @@ if len(sys.argv) < 4 or not os.path.isdir(sys.argv[2]) or not os.path.isdir(sys.
     print("Usage: [release_tag, format: v1.2.3] [artifact_dir] [jdbc_root_path]")
     exit(1)
 
-version_regex = re.compile(r'^v((\d+)\.(\d+)\.\d+)$')
+version_regex = re.compile(r'^v((\d+)\.(\d+)\.\d+\.\d+)$')
 release_tag = sys.argv[1]
 deploy_url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
 is_release = True


### PR DESCRIPTION
DuckDB is using 3-part version number. Sometimes it may be necessary to make an updated JDBC release with the changes only in JDBC/JNI code keeping the engine version the same. For this it is proposed to add fourth component to version number for JDBC-specific changes. So the version is supposed to look like `v1.2.2.0`.

Testing: JAR bundling with 4-part version was tested in a separate repo.