### PR TITLE
Prepared statement enhancements

### DIFF
--- a/src/main/java/org/duckdb/DuckDBPreparedStatement.java
+++ b/src/main/java/org/duckdb/DuckDBPreparedStatement.java
@@ -1,14 +1,17 @@
 package org.duckdb;
 
+import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.duckdb.StatementReturnType.*;
+import static org.duckdb.io.IOUtils.*;
 
-import java.io.IOException;
+import java.io.*;
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
 import java.net.URL;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.sql.Array;
 import java.sql.Blob;
 import java.sql.Clob;
@@ -29,19 +32,14 @@ import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
+import java.time.*;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class DuckDBPreparedStatement implements PreparedStatement {
-    private static final Logger logger = Logger.getLogger(DuckDBPreparedStatement.class.getName());
-
     private DuckDBConnection conn;
 
     private ByteBuffer stmtRef = null;
@@ -361,41 +359,47 @@ public class DuckDBPreparedStatement implements PreparedStatement {
         return conn == null || conn.connRef == null;
     }
 
+    @Override
     protected void finalize() throws Throwable {
         close();
     }
 
     @Override
     public int getMaxFieldSize() throws SQLException {
+        checkOpen();
         return 0;
     }
 
     @Override
     public void setMaxFieldSize(int max) throws SQLException {
-        logger.log(Level.FINE, "setMaxFieldSize not supported");
+        checkOpen();
     }
 
     @Override
     public int getMaxRows() throws SQLException {
+        checkOpen();
         return 0;
     }
 
     @Override
     public void setMaxRows(int max) throws SQLException {
+        checkOpen();
     }
 
     @Override
     public void setEscapeProcessing(boolean enable) throws SQLException {
+        checkOpen();
     }
 
     @Override
     public int getQueryTimeout() throws SQLException {
+        checkOpen();
         return 0;
     }
 
     @Override
     public void setQueryTimeout(int seconds) throws SQLException {
-        logger.log(Level.FINE, "setQueryTimeout not supported");
+        checkOpen();
     }
 
     @Override
@@ -413,21 +417,20 @@ public class DuckDBPreparedStatement implements PreparedStatement {
 
     @Override
     public SQLWarning getWarnings() throws SQLException {
+        checkOpen();
         return null;
     }
 
     @Override
     public void clearWarnings() throws SQLException {
+        checkOpen();
     }
 
     @Override
     public void setCursorName(String name) throws SQLException {
-        throw new SQLFeatureNotSupportedException("setCursorName");
+        checkOpen();
     }
 
-    /**
-     * The returned `ResultSet` must be closed by the user to avoid a memory leak
-     */
     @Override
     public ResultSet getResultSet() throws SQLException {
         if (isClosed()) {
@@ -471,11 +474,13 @@ public class DuckDBPreparedStatement implements PreparedStatement {
 
     @Override
     public boolean getMoreResults() throws SQLException {
+        checkOpen();
         return false;
     }
 
     @Override
     public void setFetchDirection(int direction) throws SQLException {
+        checkOpen();
         if (direction == ResultSet.FETCH_FORWARD) {
             return;
         }
@@ -484,30 +489,36 @@ public class DuckDBPreparedStatement implements PreparedStatement {
 
     @Override
     public int getFetchDirection() throws SQLException {
+        checkOpen();
         return ResultSet.FETCH_FORWARD;
     }
 
     @Override
     public void setFetchSize(int rows) throws SQLException {
+        checkOpen();
     }
 
     @Override
     public int getFetchSize() throws SQLException {
+        checkOpen();
         return DuckDBNative.duckdb_jdbc_fetch_size();
     }
 
     @Override
     public int getResultSetConcurrency() throws SQLException {
+        checkOpen();
         return ResultSet.CONCUR_READ_ONLY;
     }
 
     @Override
     public int getResultSetType() throws SQLException {
+        checkOpen();
         return ResultSet.TYPE_FORWARD_ONLY;
     }
 
     @Override
     public void addBatch(String sql) throws SQLException {
+        checkOpen();
         requireNonPreparedStatement();
         this.batchedStatements.add(sql);
         this.isBatch = true;
@@ -515,6 +526,7 @@ public class DuckDBPreparedStatement implements PreparedStatement {
 
     @Override
     public void clearBatch() throws SQLException {
+        checkOpen();
         this.batchedParams.clear();
         this.batchedStatements.clear();
         this.isBatch = false;
@@ -522,6 +534,7 @@ public class DuckDBPreparedStatement implements PreparedStatement {
 
     @Override
     public int[] executeBatch() throws SQLException {
+        checkOpen();
         try {
             if (this.isPreparedStatement) {
                 return executeBatchedPreparedStatement();
@@ -559,78 +572,96 @@ public class DuckDBPreparedStatement implements PreparedStatement {
 
     @Override
     public Connection getConnection() throws SQLException {
-        if (isClosed()) {
-            throw new SQLException("Statement was closed");
-        }
+        checkOpen();
         return conn;
     }
 
     @Override
     public boolean getMoreResults(int current) throws SQLException {
-        throw new SQLFeatureNotSupportedException("getMoreResults");
+        checkOpen();
+        return false;
     }
 
     @Override
     public ResultSet getGeneratedKeys() throws SQLException {
+        checkOpen();
         throw new SQLFeatureNotSupportedException("getGeneratedKeys");
     }
 
     @Override
     public int executeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
-        throw new SQLFeatureNotSupportedException("executeUpdate");
+        if (NO_GENERATED_KEYS == autoGeneratedKeys) {
+            return executeUpdate(sql);
+        }
+        throw new SQLFeatureNotSupportedException("executeUpdate(String sql, int autoGeneratedKeys)");
     }
 
     @Override
     public int executeUpdate(String sql, int[] columnIndexes) throws SQLException {
-        throw new SQLFeatureNotSupportedException("executeUpdate");
+        if (columnIndexes == null || columnIndexes.length == 0) {
+            return executeUpdate(sql);
+        }
+        throw new SQLFeatureNotSupportedException("executeUpdate(String sql, int[] columnIndexes)");
     }
 
     @Override
     public int executeUpdate(String sql, String[] columnNames) throws SQLException {
-        throw new SQLFeatureNotSupportedException("executeUpdate");
+        if (columnNames == null || columnNames.length == 0) {
+            return executeUpdate(sql);
+        }
+        throw new SQLFeatureNotSupportedException("executeUpdate(String sql, String[] columnNames)");
     }
 
     @Override
     public boolean execute(String sql, int autoGeneratedKeys) throws SQLException {
-        throw new SQLFeatureNotSupportedException("execute");
+        if (NO_GENERATED_KEYS == autoGeneratedKeys) {
+            return execute(sql);
+        }
+        throw new SQLFeatureNotSupportedException("execute(String sql, int autoGeneratedKeys)");
     }
 
     @Override
     public boolean execute(String sql, int[] columnIndexes) throws SQLException {
-        throw new SQLFeatureNotSupportedException("execute");
+        if (columnIndexes == null || columnIndexes.length == 0) {
+            return execute(sql);
+        }
+        throw new SQLFeatureNotSupportedException("execute(String sql, int[] columnIndexes)");
     }
 
     @Override
     public boolean execute(String sql, String[] columnNames) throws SQLException {
-        throw new SQLFeatureNotSupportedException("execute");
+        if (columnNames == null || columnNames.length == 0) {
+            return execute(sql);
+        }
+        throw new SQLFeatureNotSupportedException("execute(String sql, String[] columnNames)");
     }
 
     @Override
     public int getResultSetHoldability() throws SQLException {
-        throw new SQLFeatureNotSupportedException("getResultSetHoldability");
+        checkOpen();
+        return ResultSet.HOLD_CURSORS_OVER_COMMIT;
     }
 
     @Override
     public void setPoolable(boolean poolable) throws SQLException {
-        throw new SQLFeatureNotSupportedException("setPoolable");
+        checkOpen();
     }
 
     @Override
     public boolean isPoolable() throws SQLException {
-        throw new SQLFeatureNotSupportedException("isPoolable");
+        checkOpen();
+        return false;
     }
 
     @Override
     public void closeOnCompletion() throws SQLException {
         checkOpen();
-        ;
-        closeOnCompletion = true;
+        this.closeOnCompletion = true;
     }
 
     @Override
     public boolean isCloseOnCompletion() throws SQLException {
         checkOpen();
-        ;
         return closeOnCompletion;
     }
 
@@ -651,32 +682,32 @@ public class DuckDBPreparedStatement implements PreparedStatement {
 
     @Override
     public void setDate(int parameterIndex, Date x) throws SQLException {
-        setObject(parameterIndex, x);
+        setDate(parameterIndex, x, null);
     }
 
     @Override
     public void setTime(int parameterIndex, Time x) throws SQLException {
-        setObject(parameterIndex, x);
+        setTime(parameterIndex, x, null);
     }
 
     @Override
     public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException {
-        setObject(parameterIndex, x);
+        setTimestamp(parameterIndex, x, null);
     }
 
     @Override
     public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException {
-        throw new SQLFeatureNotSupportedException("setAsciiStream");
+        setAsciiStream(parameterIndex, x, (long) length);
     }
 
     @Override
     public void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException {
-        throw new SQLFeatureNotSupportedException("setUnicodeStream");
+        setCharacterStreamInternal(parameterIndex, x, length, UTF_8);
     }
 
     @Override
     public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException {
-        throw new SQLFeatureNotSupportedException("setBinaryStream");
+        setBinaryStream(parameterIndex, x, (long) length);
     }
 
     @Override
@@ -827,7 +858,7 @@ public class DuckDBPreparedStatement implements PreparedStatement {
 
     @Override
     public void setCharacterStream(int parameterIndex, Reader reader, int length) throws SQLException {
-        throw new SQLFeatureNotSupportedException("setCharacterStream");
+        setCharacterStream(parameterIndex, reader, (long) length);
     }
 
     @Override
@@ -837,86 +868,120 @@ public class DuckDBPreparedStatement implements PreparedStatement {
 
     @Override
     public void setRef(int parameterIndex, Ref x) throws SQLException {
+        checkOpen();
         throw new SQLFeatureNotSupportedException("setRef");
     }
 
     @Override
     public void setBlob(int parameterIndex, Blob x) throws SQLException {
+        checkOpen();
         throw new SQLFeatureNotSupportedException("setBlob");
     }
 
     @Override
     public void setClob(int parameterIndex, Clob x) throws SQLException {
+        checkOpen();
         throw new SQLFeatureNotSupportedException("setClob");
     }
 
     @Override
     public void setArray(int parameterIndex, Array x) throws SQLException {
-        throw new SQLFeatureNotSupportedException("setArray");
+        setObject(parameterIndex, x);
     }
 
     @Override
     public void setDate(int parameterIndex, Date x, Calendar cal) throws SQLException {
-        throw new SQLFeatureNotSupportedException("setDate");
+        if (null == x || null == cal) {
+            setObject(parameterIndex, x);
+            return;
+        }
+        Instant instant = Instant.ofEpochMilli(x.getTime());
+        ZoneId zoneId = cal.getTimeZone().toZoneId();
+        ZonedDateTime zdt = ZonedDateTime.ofInstant(instant, zoneId);
+        LocalDate ld = zdt.toLocalDate();
+        setObject(parameterIndex, ld);
     }
 
     @Override
     public void setTime(int parameterIndex, Time x, Calendar cal) throws SQLException {
-        throw new SQLFeatureNotSupportedException("setTime");
+        if (null == x || null == cal) {
+            setObject(parameterIndex, x);
+            return;
+        }
+        Instant instant = Instant.ofEpochMilli(x.getTime());
+        ZoneId zoneId = cal.getTimeZone().toZoneId();
+        ZonedDateTime zdt = ZonedDateTime.ofInstant(instant, zoneId);
+        LocalTime lt = zdt.toLocalTime();
+        setObject(parameterIndex, lt);
     }
 
     @Override
     public void setTimestamp(int parameterIndex, Timestamp x, Calendar cal) throws SQLException {
-        throw new SQLFeatureNotSupportedException("setTimestamp");
+        if (null == x || null == cal) {
+            setObject(parameterIndex, x);
+            return;
+        }
+        Instant instant = Instant.ofEpochMilli(x.getTime());
+        ZoneId zoneId = cal.getTimeZone().toZoneId();
+        ZonedDateTime zdt = ZonedDateTime.ofInstant(instant, zoneId);
+        LocalDateTime ldt = zdt.toLocalDateTime();
+        setObject(parameterIndex, ldt);
     }
 
     @Override
     public void setNull(int parameterIndex, int sqlType, String typeName) throws SQLException {
-        throw new SQLFeatureNotSupportedException("setNull");
+        setNull(parameterIndex, sqlType);
     }
 
     @Override
     public void setURL(int parameterIndex, URL x) throws SQLException {
+        checkOpen();
         throw new SQLFeatureNotSupportedException("setURL");
     }
 
     @Override
     public void setRowId(int parameterIndex, RowId x) throws SQLException {
+        checkOpen();
         throw new SQLFeatureNotSupportedException("setRowId");
     }
 
     @Override
     public void setNString(int parameterIndex, String value) throws SQLException {
-        throw new SQLFeatureNotSupportedException("setNString");
+        setString(parameterIndex, value);
     }
 
     @Override
     public void setNCharacterStream(int parameterIndex, Reader value, long length) throws SQLException {
-        throw new SQLFeatureNotSupportedException("setNCharacterString");
+        setCharacterStream(parameterIndex, value, length);
     }
 
     @Override
     public void setNClob(int parameterIndex, NClob value) throws SQLException {
+        checkOpen();
         throw new SQLFeatureNotSupportedException("setNClob");
     }
 
     @Override
     public void setClob(int parameterIndex, Reader reader, long length) throws SQLException {
+        checkOpen();
         throw new SQLFeatureNotSupportedException("setClob");
     }
 
     @Override
     public void setBlob(int parameterIndex, InputStream inputStream, long length) throws SQLException {
+        checkOpen();
         throw new SQLFeatureNotSupportedException("setBlob");
     }
 
     @Override
     public void setNClob(int parameterIndex, Reader reader, long length) throws SQLException {
+        checkOpen();
         throw new SQLFeatureNotSupportedException("setNClob");
     }
 
     @Override
     public void setSQLXML(int parameterIndex, SQLXML xmlObject) throws SQLException {
+        checkOpen();
         throw new SQLFeatureNotSupportedException("setSQLXML");
     }
 
@@ -927,17 +992,20 @@ public class DuckDBPreparedStatement implements PreparedStatement {
 
     @Override
     public void setAsciiStream(int parameterIndex, InputStream x, long length) throws SQLException {
-        throw new SQLFeatureNotSupportedException("setAsciiStream");
+        setCharacterStreamInternal(parameterIndex, x, length, US_ASCII);
     }
 
     @Override
     public void setBinaryStream(int parameterIndex, InputStream x, long length) throws SQLException {
-        throw new SQLFeatureNotSupportedException("setBinaryStream");
+        checkOpen();
+        InputStream stream = wrapStreamWithMaxBytes(x, length);
+        byte[] bytes = readAllBytes(stream);
+        setObject(parameterIndex, bytes);
     }
 
     @Override
     public void setCharacterStream(int parameterIndex, Reader reader, long length) throws SQLException {
-        throw new SQLFeatureNotSupportedException("setCharacterStream");
+        setCharacterReaderInternal(parameterIndex, reader, length);
     }
 
     @Override
@@ -947,35 +1015,34 @@ public class DuckDBPreparedStatement implements PreparedStatement {
 
     @Override
     public void setBinaryStream(int parameterIndex, InputStream x) throws SQLException {
-        try {
-            setBytes(parameterIndex, JdbcUtils.readAllBytes(x));
-        } catch (IOException ioe) {
-            throw new SQLException("Failed to read from InputStream", ioe);
-        }
+        setBinaryStream(parameterIndex, x, -1);
     }
 
     @Override
     public void setCharacterStream(int parameterIndex, Reader reader) throws SQLException {
-        throw new SQLFeatureNotSupportedException("setCharacterStream");
+        setCharacterStream(parameterIndex, reader, -1);
     }
 
     @Override
     public void setNCharacterStream(int parameterIndex, Reader value) throws SQLException {
-        throw new SQLFeatureNotSupportedException("setNCharacterStream");
+        setNCharacterStream(parameterIndex, value, -1);
     }
 
     @Override
     public void setClob(int parameterIndex, Reader reader) throws SQLException {
+        checkOpen();
         throw new SQLFeatureNotSupportedException("setClob");
     }
 
     @Override
     public void setBlob(int parameterIndex, InputStream inputStream) throws SQLException {
+        checkOpen();
         throw new SQLFeatureNotSupportedException("setBlob");
     }
 
     @Override
     public void setNClob(int parameterIndex, Reader reader) throws SQLException {
+        checkOpen();
         throw new SQLFeatureNotSupportedException("setNClob");
     }
 
@@ -1001,5 +1068,21 @@ public class DuckDBPreparedStatement implements PreparedStatement {
         if (stmtRef == null) {
             throw new SQLException("Prepare something first");
         }
+    }
+
+    private void setCharacterStreamInternal(int parameterIndex, InputStream x, long length, Charset charset)
+        throws SQLException {
+        checkOpen();
+        InputStream stream = wrapStreamWithMaxBytes(x, length);
+        Reader reader = new InputStreamReader(stream, charset);
+        String str = readToString(reader);
+        setObject(parameterIndex, str);
+    }
+
+    private void setCharacterReaderInternal(int parameterIndex, Reader reader, long lenght) throws SQLException {
+        checkOpen();
+        Reader wrappedReader = wrapReaderWithMaxChars(reader, lenght);
+        String str = readToString(wrappedReader);
+        setObject(parameterIndex, str);
     }
 }

--- a/src/main/java/org/duckdb/DuckDBTime.java
+++ b/src/main/java/org/duckdb/DuckDBTime.java
@@ -1,12 +1,29 @@
 package org.duckdb;
 
 import java.sql.Time;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.*;
+import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
 public class DuckDBTime extends DuckDBTimestamp {
     public DuckDBTime(Time time) {
-        super(TimeUnit.MILLISECONDS.toMicros(time.getTime()));
+        super(TimeUnit.MILLISECONDS.toMicros(timeToMillis(time)));
+    }
+
+    public DuckDBTime(LocalTime lt) {
+        super(TimeUnit.NANOSECONDS.toMicros(lt.toNanoOfDay()));
+    }
+
+    private static long timeToMillis(Time time) {
+        // Per JDBC spec PreparedStatement#setTime() must NOT use
+        // default JVM time zone.
+        // The Time we have is already shifted with the default time zone,
+        // so we need to shift it back to keep hours/minutes/seconds
+        // values intact.
+        Instant instant = Instant.ofEpochMilli(time.getTime());
+        ZoneId zoneId = TimeZone.getDefault().toZoneId();
+        LocalDateTime ldt = LocalDateTime.ofInstant(instant, zoneId);
+        ZonedDateTime utc = ldt.atZone(ZoneId.of("UTC"));
+        return utc.toInstant().toEpochMilli();
     }
 }

--- a/src/main/java/org/duckdb/DuckDBTimestamp.java
+++ b/src/main/java/org/duckdb/DuckDBTimestamp.java
@@ -121,6 +121,8 @@ public class DuckDBTimestamp {
             x = new DuckDBDate((Date) x);
         } else if (x instanceof Time) {
             x = new DuckDBTime((Time) x);
+        } else if (x instanceof LocalTime) {
+            x = new DuckDBTime((LocalTime) x);
         }
         return x;
     }

--- a/src/main/java/org/duckdb/JdbcUtils.java
+++ b/src/main/java/org/duckdb/JdbcUtils.java
@@ -1,8 +1,5 @@
 package org.duckdb;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.sql.SQLException;
 
 final class JdbcUtils {
@@ -13,18 +10,6 @@ final class JdbcUtils {
             throw new SQLException(obj.getClass().getName() + " not unwrappable from " + iface.getName());
         }
         return (T) obj;
-    }
-
-    static byte[] readAllBytes(InputStream x) throws IOException {
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        byte[] thing = new byte[256];
-        int length;
-        int offset = 0;
-        while ((length = x.read(thing)) != -1) {
-            out.write(thing, offset, length);
-            offset += length;
-        }
-        return out.toByteArray();
     }
 
     private JdbcUtils() {

--- a/src/main/java/org/duckdb/io/IOUtils.java
+++ b/src/main/java/org/duckdb/io/IOUtils.java
@@ -1,0 +1,52 @@
+package org.duckdb.io;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.sql.SQLException;
+
+public class IOUtils {
+
+    public static byte[] readAllBytes(InputStream x) throws SQLException {
+        try {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            byte[] buffer = new byte[8192];
+            int length;
+            while ((length = x.read(buffer)) != -1) {
+                out.write(buffer, 0, length);
+            }
+            return out.toByteArray();
+        } catch (IOException e) {
+            throw new SQLException(e);
+        }
+    }
+
+    public static String readToString(Reader reader) throws SQLException {
+        try {
+            StringBuilder sb = new StringBuilder();
+            char[] buffer = new char[4096];
+            int length;
+            while ((length = reader.read(buffer)) != -1) {
+                sb.append(buffer, 0, length);
+            }
+            return sb.toString();
+        } catch (IOException e) {
+            throw new SQLException();
+        }
+    }
+
+    public static InputStream wrapStreamWithMaxBytes(InputStream is, long maxBytes) {
+        if (maxBytes < 0) {
+            return is;
+        }
+        return new LimitedInputStream(is, maxBytes);
+    }
+
+    public static Reader wrapReaderWithMaxChars(Reader reader, long maxChars) {
+        if (maxChars < 0) {
+            return reader;
+        }
+        return new LimitedReader(reader, maxChars);
+    }
+}

--- a/src/main/java/org/duckdb/io/LimitedInputStream.java
+++ b/src/main/java/org/duckdb/io/LimitedInputStream.java
@@ -1,0 +1,54 @@
+package org.duckdb.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class LimitedInputStream extends InputStream {
+    private final InputStream source;
+    private final long maxBytesToRead;
+    private long bytesRead;
+
+    public LimitedInputStream(InputStream source, long maxBytesToRead) {
+        if (source == null) {
+            throw new IllegalArgumentException("Source input stream cannot be null");
+        }
+        if (maxBytesToRead < 0) {
+            throw new IllegalArgumentException("maxBytesToRead must be non-negative");
+        }
+        this.source = source;
+        this.maxBytesToRead = maxBytesToRead;
+        this.bytesRead = 0;
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (bytesRead >= maxBytesToRead) {
+            return -1; // EOF
+        }
+        int result = source.read();
+        if (result != -1) {
+            bytesRead++;
+        }
+        return result;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        if (bytesRead >= maxBytesToRead) {
+            return -1; // EOF
+        }
+        // Calculate the maximum number of bytes we can read
+        long bytesRemaining = maxBytesToRead - bytesRead;
+        int bytesToRead = (int) Math.min(len, bytesRemaining);
+        int result = source.read(b, off, bytesToRead);
+        if (result != -1) {
+            bytesRead += result;
+        }
+        return result;
+    }
+
+    @Override
+    public void close() throws IOException {
+        source.close();
+    }
+}

--- a/src/main/java/org/duckdb/io/LimitedReader.java
+++ b/src/main/java/org/duckdb/io/LimitedReader.java
@@ -1,0 +1,53 @@
+package org.duckdb.io;
+
+import java.io.IOException;
+import java.io.Reader;
+
+public class LimitedReader extends Reader {
+    private final Reader source;
+    private final long maxCharsToRead;
+    private long charsRead;
+
+    public LimitedReader(Reader source, long maxCharsToRead) {
+        if (source == null) {
+            throw new IllegalArgumentException("Source Reader cannot be null");
+        }
+        if (maxCharsToRead < 0) {
+            throw new IllegalArgumentException("maxCharsToRead must be non-negative");
+        }
+        this.source = source;
+        this.maxCharsToRead = maxCharsToRead;
+        this.charsRead = 0;
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (charsRead >= maxCharsToRead) {
+            return -1; // EOF
+        }
+        int result = source.read();
+        if (result != -1) {
+            charsRead++;
+        }
+        return result;
+    }
+
+    @Override
+    public int read(char[] cbuf, int off, int len) throws IOException {
+        if (charsRead >= maxCharsToRead) {
+            return -1; // EOF
+        }
+        long charsRemaining = maxCharsToRead - charsRead;
+        int charsToRead = (int) Math.min(len, charsRemaining);
+        int result = source.read(cbuf, off, charsToRead);
+        if (result != -1) {
+            charsRead += result;
+        }
+        return result;
+    }
+
+    @Override
+    public void close() throws IOException {
+        source.close();
+    }
+}

--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -1,5 +1,6 @@
 package org.duckdb;
 
+import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
 import static java.time.temporal.ChronoField.DAY_OF_MONTH;
 import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
@@ -14,6 +15,8 @@ import static org.duckdb.DuckDBTimestamp.localDateTimeFromTimestamp;
 import static org.duckdb.test.Assertions.*;
 import static org.duckdb.test.Runner.runTests;
 
+import java.io.ByteArrayInputStream;
+import java.io.StringReader;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
@@ -29,15 +32,11 @@ import java.time.format.ResolverStyle;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.ListIterator;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.TimeZone;
@@ -328,207 +327,6 @@ public class TestDuckDBJDBC {
         conn.close();
     }
 
-    public static void test_timestamp_ms() throws Exception {
-        String expectedString = "2022-08-17 12:11:10.999";
-        String sql = "SELECT '2022-08-17T12:11:10.999'::TIMESTAMP_MS as ts_ms";
-        assert_timestamp_match(sql, expectedString, "TIMESTAMP_MS");
-    }
-
-    public static void test_timestamp_ns() throws Exception {
-        String expectedString = "2022-08-17 12:11:10.999999999";
-        String sql = "SELECT '2022-08-17T12:11:10.999999999'::TIMESTAMP_NS as ts_ns";
-        assert_timestamp_match(sql, expectedString, "TIMESTAMP_NS");
-    }
-
-    public static void test_timestamp_s() throws Exception {
-        String expectedString = "2022-08-17 12:11:10";
-        String sql = "SELECT '2022-08-17T12:11:10'::TIMESTAMP_S as ts_s";
-        assert_timestamp_match(sql, expectedString, "TIMESTAMP_S");
-    }
-
-    private static void assert_timestamp_match(String fetchSql, String expectedString, String expectedTypeName)
-        throws Exception {
-        String originalTzProperty = System.getProperty("user.timezone");
-        TimeZone originalTz = TimeZone.getDefault();
-        try {
-            TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
-            System.setProperty("user.timezone", "UTC");
-            Connection conn = DriverManager.getConnection(JDBC_URL);
-            Statement stmt = conn.createStatement();
-
-            ResultSet rs = stmt.executeQuery(fetchSql);
-            assertTrue(rs.next());
-            Timestamp actual = rs.getTimestamp(1);
-
-            Timestamp expected = Timestamp.valueOf(expectedString);
-
-            assertEquals(expected.getTime(), actual.getTime());
-            assertEquals(expected.getNanos(), actual.getNanos());
-
-            assertEquals(Types.TIMESTAMP, rs.getMetaData().getColumnType(1));
-            assertEquals(expectedTypeName, rs.getMetaData().getColumnTypeName(1));
-
-            rs.close();
-            stmt.close();
-            conn.close();
-        } finally {
-            TimeZone.setDefault(originalTz);
-            System.setProperty("user.timezone", originalTzProperty);
-        }
-    }
-
-    public static void test_timestamp_tz() throws Exception {
-        Connection conn = DriverManager.getConnection(JDBC_URL);
-        Statement stmt = conn.createStatement();
-
-        ResultSet rs;
-
-        stmt.execute("CREATE TABLE t (id INT, t1 TIMESTAMPTZ)");
-        stmt.execute("INSERT INTO t (id, t1) VALUES (1, '2022-01-01T12:11:10+02')");
-        stmt.execute("INSERT INTO t (id, t1) VALUES (2, '2022-01-01T12:11:10Z')");
-
-        PreparedStatement ps = conn.prepareStatement("INSERT INTO T (id, t1) VALUES (?, ?)");
-
-        OffsetDateTime odt1 = OffsetDateTime.of(2020, 10, 7, 13, 15, 7, 12345, ZoneOffset.ofHours(7));
-        OffsetDateTime odt1Rounded = OffsetDateTime.of(2020, 10, 7, 13, 15, 7, 12000, ZoneOffset.ofHours(7));
-        OffsetDateTime odt2 = OffsetDateTime.of(1878, 10, 2, 1, 15, 7, 12345, ZoneOffset.ofHours(-5));
-        OffsetDateTime odt2Rounded = OffsetDateTime.of(1878, 10, 2, 1, 15, 8, 13000, ZoneOffset.ofHours(-5));
-        OffsetDateTime odt3 = OffsetDateTime.of(2022, 1, 1, 12, 11, 10, 0, ZoneOffset.ofHours(2));
-        OffsetDateTime odt4 = OffsetDateTime.of(2022, 1, 1, 12, 11, 10, 0, ZoneOffset.ofHours(0));
-        OffsetDateTime odt5 = OffsetDateTime.of(1900, 11, 27, 23, 59, 59, 0, ZoneOffset.ofHours(1));
-
-        ps.setObject(1, 3);
-        ps.setObject(2, odt1);
-        ps.execute();
-        ps.setObject(1, 4);
-        ps.setObject(2, odt5, Types.TIMESTAMP_WITH_TIMEZONE);
-        ps.execute();
-        ps.setObject(1, 5);
-        ps.setObject(2, odt2);
-        ps.execute();
-
-        rs = stmt.executeQuery("SELECT * FROM t ORDER BY id");
-        ResultSetMetaData meta = rs.getMetaData();
-        rs.next();
-        assertTrue(rs.getObject(2, OffsetDateTime.class).isEqual(odt3));
-        rs.next();
-        assertEquals(rs.getObject(2, OffsetDateTime.class), odt4);
-        rs.next();
-        assertTrue(rs.getObject(2, OffsetDateTime.class).isEqual(odt1Rounded));
-        rs.next();
-        assertTrue(rs.getObject(2, OffsetDateTime.class).isEqual(odt5));
-        rs.next();
-        assertTrue(rs.getObject(2, OffsetDateTime.class).isEqual(odt2Rounded));
-        assertTrue(((OffsetDateTime) rs.getObject(2)).isEqual(odt2Rounded));
-
-        // Metadata tests
-        assertEquals(
-            Types.TIMESTAMP_WITH_TIMEZONE,
-            (meta.unwrap(DuckDBResultSetMetaData.class).type_to_int(DuckDBColumnType.TIMESTAMP_WITH_TIME_ZONE)));
-        assertTrue(OffsetDateTime.class.getName().equals(meta.getColumnClassName(2)));
-
-        rs.close();
-        stmt.close();
-        conn.close();
-    }
-
-    public static void test_timestamp_as_long() throws Exception {
-        Connection conn = DriverManager.getConnection(JDBC_URL);
-        Statement stmt = conn.createStatement();
-
-        ResultSet rs;
-
-        stmt.execute("CREATE TABLE t (id INT, t1 TIMESTAMP)");
-        stmt.execute("INSERT INTO t (id, t1) VALUES (1, '2022-01-01T12:11:10')");
-        stmt.execute("INSERT INTO t (id, t1) VALUES (2, '2022-01-01T12:11:11')");
-
-        rs = stmt.executeQuery("SELECT * FROM t ORDER BY id");
-        rs.next();
-        assertEquals(rs.getLong(2), 1641039070000000L);
-        rs.next();
-        assertEquals(rs.getLong(2), 1641039071000000L);
-
-        rs.close();
-        stmt.close();
-        conn.close();
-    }
-
-    public static void test_timestamptz_as_long() throws Exception {
-        Connection conn = DriverManager.getConnection(JDBC_URL);
-        Statement stmt = conn.createStatement();
-
-        ResultSet rs;
-
-        stmt.execute("SET CALENDAR='gregorian'");
-        stmt.execute("SET TIMEZONE='America/Los_Angeles'");
-        stmt.execute("CREATE TABLE t (id INT, t1 TIMESTAMPTZ)");
-        stmt.execute("INSERT INTO t (id, t1) VALUES (1, '2022-01-01T12:11:10Z')");
-        stmt.execute("INSERT INTO t (id, t1) VALUES (2, '2022-01-01T12:11:11Z')");
-
-        rs = stmt.executeQuery("SELECT * FROM t ORDER BY id");
-        rs.next();
-        assertEquals(rs.getLong(2), 1641039070000000L);
-        rs.next();
-        assertEquals(rs.getLong(2), 1641039071000000L);
-
-        rs.close();
-        stmt.close();
-        conn.close();
-    }
-
-    public static void test_consecutive_timestamps() throws Exception {
-        long expected = 986860800000L;
-        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement()) {
-            try (ResultSet rs = stmt.executeQuery(
-                     "select range from range(TIMESTAMP '2001-04-10', TIMESTAMP '2001-04-11', INTERVAL 30 MINUTE)")) {
-                Calendar cal = GregorianCalendar.getInstance();
-                cal.setTimeZone(TimeZone.getTimeZone("UTC"));
-                while (rs.next()) {
-                    Timestamp actual = rs.getTimestamp(1, cal);
-                    assertEquals(expected, actual.getTime());
-                    expected += 30 * 60 * 1_000;
-                }
-            }
-        }
-    }
-
-    public static void test_timestamp_getters() throws Exception {
-        TimeZone defaultTimeZone = TimeZone.getDefault();
-        TimeZone activeTimeZone = TimeZone.getTimeZone("Europe/Sofia");
-        TimeZone.setDefault(activeTimeZone);
-        try {
-            try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement s = conn.createStatement()) {
-                try (ResultSet rs = s.executeQuery(
-                         "SELECT '2020-01-01 01:23:45.678901 Australia/Darwin'::TIMESTAMP WITH TIME ZONE")) {
-                    rs.next();
-                    assertEquals("2019-12-31 17:53:45.678901", rs.getTimestamp(1).toString());
-                    assertEquals(1577807625678L, rs.getTimestamp(1).getTime());
-                    assertEquals("2019-12-31", rs.getDate(1).toString());
-                    assertEquals("Tue Dec 31 00:00:00 EET 2019",
-                                 new java.util.Date(rs.getDate(1).getTime()).toString());
-                    assertEquals("17:53:45", rs.getTime(1).toString());
-                    assertEquals("2019-12-31T17:53:45.678901", rs.getTimestamp(1).toLocalDateTime().toString());
-                    Calendar cal = GregorianCalendar.getInstance();
-                    cal.setTimeZone(TimeZone.getTimeZone("America/New_York"));
-                    assertEquals("2019-12-31 10:53:45.678901", rs.getTimestamp(1, cal).toString());
-                    assertEquals(1577782425678L, rs.getTimestamp(1, cal).getTime());
-                }
-                try (ResultSet rs =
-                         s.executeQuery("SELECT '2020-01-01 01:23:45.678901'::TIMESTAMP WITHOUT TIME ZONE")) {
-                    rs.next();
-                    assertEquals("2020-01-01 01:23:45.678901", rs.getTimestamp(1).toString());
-                    assertEquals(1577834625678L, rs.getTimestamp(1).getTime());
-                    Calendar cal = GregorianCalendar.getInstance();
-                    cal.setTimeZone(TimeZone.getTimeZone("America/New_York"));
-                    assertEquals("2020-01-01 08:23:45.678901", rs.getTimestamp(1, cal).toString());
-                    assertEquals(1577859825678L, rs.getTimestamp(1, cal).getTime());
-                }
-            }
-        } finally {
-            TimeZone.setDefault(defaultTimeZone);
-        }
-    }
-
     public static void test_throw_wrong_datatype() throws Exception {
         Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
@@ -770,174 +568,6 @@ public class TestDuckDBJDBC {
         stmt1.close();
     }
 
-    public static void test_duckdb_timestamp() throws Exception {
-
-        duckdb_timestamp_test();
-
-        // Store default time zone
-        TimeZone defaultTZ = TimeZone.getDefault();
-
-        // Test with different time zones
-        TimeZone.setDefault(TimeZone.getTimeZone("America/Lima"));
-        duckdb_timestamp_test();
-
-        // Test with different time zones
-        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Berlin"));
-        duckdb_timestamp_test();
-
-        // Restore default time zone
-        TimeZone.setDefault(defaultTZ);
-    }
-
-    public static void duckdb_timestamp_test() throws Exception {
-        Connection conn = DriverManager.getConnection(JDBC_URL);
-        Statement stmt = conn.createStatement();
-        stmt.execute("CREATE TABLE a (ts TIMESTAMP)");
-
-        // Generate tests without database
-        Timestamp ts0 = Timestamp.valueOf("1970-01-01 00:00:00");
-        Timestamp ts1 = Timestamp.valueOf("2021-07-29 21:13:11");
-        Timestamp ts2 = Timestamp.valueOf("2021-07-29 21:13:11.123456");
-        Timestamp ts3 = Timestamp.valueOf("1921-07-29 21:13:11");
-        Timestamp ts4 = Timestamp.valueOf("1921-07-29 21:13:11.123456");
-
-        Timestamp cts0 = new DuckDBTimestamp(ts0).toSqlTimestamp();
-        Timestamp cts1 = new DuckDBTimestamp(ts1).toSqlTimestamp();
-        Timestamp cts2 = new DuckDBTimestamp(ts2).toSqlTimestamp();
-        Timestamp cts3 = new DuckDBTimestamp(ts3).toSqlTimestamp();
-        Timestamp cts4 = new DuckDBTimestamp(ts4).toSqlTimestamp();
-
-        assertTrue(ts0.getTime() == cts0.getTime());
-        assertTrue(ts0.compareTo(cts0) == 0);
-        assertTrue(ts1.getTime() == cts1.getTime());
-        assertTrue(ts1.compareTo(cts1) == 0);
-        assertTrue(ts2.getTime() == cts2.getTime());
-        assertTrue(ts2.compareTo(cts2) == 0);
-        assertTrue(ts3.getTime() == cts3.getTime());
-        assertTrue(ts3.compareTo(cts3) == 0);
-        assertTrue(ts4.getTime() == cts4.getTime());
-        assertTrue(ts4.compareTo(cts4) == 0);
-
-        DuckDBTimestamp dts4 = new DuckDBTimestamp(ts1);
-        assertTrue(dts4.toSqlTimestamp().compareTo(ts1) == 0);
-        DuckDBTimestamp dts5 = new DuckDBTimestamp(ts2);
-        assertTrue(dts5.toSqlTimestamp().compareTo(ts2) == 0);
-
-        // Insert and read a timestamp
-        stmt.execute("INSERT INTO a (ts) VALUES ('2005-11-02 07:59:58')");
-        ResultSet rs = stmt.executeQuery("SELECT * FROM a");
-        assertTrue(rs.next());
-        assertEquals(rs.getObject("ts"), Timestamp.valueOf("2005-11-02 07:59:58"));
-        assertEquals(rs.getTimestamp("ts"), Timestamp.valueOf("2005-11-02 07:59:58"));
-
-        rs.close();
-        stmt.close();
-
-        PreparedStatement ps = conn.prepareStatement("SELECT COUNT(ts) FROM a WHERE ts = ?");
-        ps.setTimestamp(1, Timestamp.valueOf("2005-11-02 07:59:58"));
-        ResultSet rs2 = ps.executeQuery();
-        assertTrue(rs2.next());
-        assertEquals(rs2.getInt(1), 1);
-        rs2.close();
-        ps.close();
-
-        ps = conn.prepareStatement("SELECT COUNT(ts) FROM a WHERE ts = ?");
-        ps.setObject(1, Timestamp.valueOf("2005-11-02 07:59:58"));
-        ResultSet rs3 = ps.executeQuery();
-        assertTrue(rs3.next());
-        assertEquals(rs3.getInt(1), 1);
-        rs3.close();
-        ps.close();
-
-        ps = conn.prepareStatement("SELECT COUNT(ts) FROM a WHERE ts = ?");
-        ps.setObject(1, Timestamp.valueOf("2005-11-02 07:59:58"), Types.TIMESTAMP);
-        ResultSet rs4 = ps.executeQuery();
-        assertTrue(rs4.next());
-        assertEquals(rs4.getInt(1), 1);
-        rs4.close();
-        ps.close();
-
-        Statement stmt2 = conn.createStatement();
-        stmt2.execute("INSERT INTO a (ts) VALUES ('1905-11-02 07:59:58.12345')");
-        ps = conn.prepareStatement("SELECT COUNT(ts) FROM a WHERE ts = ?");
-        ps.setTimestamp(1, Timestamp.valueOf("1905-11-02 07:59:58.12345"));
-        ResultSet rs5 = ps.executeQuery();
-        assertTrue(rs5.next());
-        assertEquals(rs5.getInt(1), 1);
-        rs5.close();
-        ps.close();
-
-        ps = conn.prepareStatement("SELECT ts FROM a WHERE ts = ?");
-        ps.setTimestamp(1, Timestamp.valueOf("1905-11-02 07:59:58.12345"));
-        ResultSet rs6 = ps.executeQuery();
-        assertTrue(rs6.next());
-        assertEquals(rs6.getTimestamp(1), Timestamp.valueOf("1905-11-02 07:59:59.12345"));
-        rs6.close();
-        ps.close();
-
-        conn.close();
-    }
-
-    public static void test_duckdb_localdatetime() throws Exception {
-        Connection conn = DriverManager.getConnection(JDBC_URL);
-        Statement stmt = conn.createStatement();
-        stmt.execute("CREATE TABLE x (ts TIMESTAMP)");
-
-        LocalDateTime ldt = LocalDateTime.of(2021, 1, 18, 21, 20, 7);
-
-        PreparedStatement ps1 = conn.prepareStatement("INSERT INTO x VALUES (?)");
-        ps1.setObject(1, ldt);
-        ps1.execute();
-        ps1.close();
-
-        PreparedStatement ps2 = conn.prepareStatement("SELECT * FROM x");
-        ResultSet rs2 = ps2.executeQuery();
-
-        rs2.next();
-        assertEquals(rs2.getTimestamp(1), rs2.getObject(1, Timestamp.class));
-        assertEquals(rs2.getObject(1, LocalDateTime.class), ldt);
-
-        rs2.close();
-        ps2.close();
-        stmt.close();
-        conn.close();
-    }
-
-    public static void test_duckdb_localdate() throws Exception {
-        Connection conn = DriverManager.getConnection(JDBC_URL);
-        Statement stmt = conn.createStatement();
-        stmt.execute("CREATE TABLE x (dt Date)");
-
-        LocalDate ld = LocalDate.of(2024, 7, 22);
-        Date date = Date.valueOf(ld);
-
-        PreparedStatement ps1 = conn.prepareStatement("INSERT INTO x VALUES (?)");
-        ps1.setObject(1, date);
-        ps1.execute();
-
-        ps1.setObject(1, ld);
-        ps1.execute();
-        ps1.close();
-
-        PreparedStatement ps2 = conn.prepareStatement("SELECT * FROM x");
-        ResultSet rs2 = ps2.executeQuery();
-
-        rs2.next();
-        assertEquals(rs2.getDate(1), rs2.getObject(1, Date.class));
-        assertEquals(rs2.getObject(1, LocalDate.class), ld);
-        assertEquals(rs2.getObject("dt", LocalDate.class), ld);
-
-        rs2.next();
-        assertEquals(rs2.getDate(1), rs2.getObject(1, Date.class));
-        assertEquals(rs2.getObject(1, LocalDate.class), ld);
-        assertEquals(rs2.getObject("dt", LocalDate.class), ld);
-
-        rs2.close();
-        ps2.close();
-        stmt.close();
-        conn.close();
-    }
-
     public static void test_duckdb_getObject_with_class() throws Exception {
         Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
@@ -1161,59 +791,6 @@ public class TestDuckDBJDBC {
         assertEquals(10, meta.getScale(5));
 
         conn.close();
-    }
-
-    // Longer, resource intensive test - might be commented out for a quick test run
-    public static void test_lots_of_timestamps() throws Exception {
-        Connection conn = DriverManager.getConnection(JDBC_URL);
-        Statement stmt = conn.createStatement();
-        stmt.execute("CREATE TABLE a (ts TIMESTAMP)");
-
-        Timestamp ts = Timestamp.valueOf("1970-01-01 01:01:01");
-
-        for (long i = 134234533L; i < 13423453300L; i = i + 735127) {
-            ts.setTime(i);
-            stmt.execute("INSERT INTO a (ts) VALUES ('" + ts + "')");
-        }
-
-        stmt.close();
-
-        for (long i = 134234533L; i < 13423453300L; i = i + 735127) {
-            PreparedStatement ps = conn.prepareStatement("SELECT COUNT(ts) FROM a WHERE ts = ?");
-            ps.setTimestamp(1, ts);
-            ResultSet rs = ps.executeQuery();
-            assertTrue(rs.next());
-            assertEquals(rs.getInt(1), 1);
-            rs.close();
-            ps.close();
-        }
-
-        conn.close();
-    }
-
-    public static void test_set_date() throws Exception {
-        try (Connection conn = DriverManager.getConnection(JDBC_URL);
-             PreparedStatement stmt = conn.prepareStatement("SELECT ?")) {
-            Date date = Date.valueOf("1969-01-01");
-            stmt.setDate(1, date);
-            ResultSet rs = stmt.executeQuery();
-            while (rs.next()) {
-                assertEquals(rs.getDate(1), date);
-            }
-        }
-    }
-
-    public static void test_set_time() throws Exception {
-        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
-        try (Connection conn = DriverManager.getConnection(JDBC_URL);
-             PreparedStatement stmt = conn.prepareStatement("SELECT ?::VARCHAR")) {
-            Time time = Time.valueOf("12:40:00");
-            stmt.setTime(1, time);
-            ResultSet rs = stmt.executeQuery();
-            while (rs.next()) {
-                assertEquals(rs.getTime(1), time);
-            }
-        }
     }
 
     public static void test_lots_of_decimals() throws Exception {
@@ -1702,64 +1279,6 @@ public class TestDuckDBJDBC {
         conn.close();
     }
 
-    public static void test_calendar_types() throws Exception {
-        Connection conn = DriverManager.getConnection(JDBC_URL);
-        Statement stmt = conn.createStatement();
-
-        //	Nail down the location for test portability.
-        Calendar cal = new GregorianCalendar(TimeZone.getTimeZone("America/Los_Angeles"), Locale.US);
-
-        ResultSet rs = stmt.executeQuery(
-            "SELECT '2019-11-26 21:11:43.123456'::timestamp ts, '2019-11-26'::date dt, '21:11:00'::time te");
-        assertTrue(rs.next());
-        assertEquals(rs.getTimestamp("ts", cal), Timestamp.valueOf("2019-11-27 05:11:43.123456"));
-
-        assertEquals(rs.getDate("dt", cal), Date.valueOf("2019-11-26"));
-
-        assertEquals(rs.getTime("te", cal), Time.valueOf("21:11:00"));
-
-        assertFalse(rs.next());
-        rs.close();
-        stmt.close();
-        conn.close();
-    }
-
-    public static void test_temporal_nulls() throws Exception {
-        Connection conn = DriverManager.getConnection(JDBC_URL);
-        Statement stmt = conn.createStatement();
-
-        ResultSet rs = stmt.executeQuery("SELECT NULL::timestamp ts, NULL::date dt, NULL::time te");
-        assertTrue(rs.next());
-        assertNull(rs.getObject("ts"));
-        assertNull(rs.getTimestamp("ts"));
-
-        assertNull(rs.getObject("dt"));
-        assertNull(rs.getDate("dt"));
-
-        assertNull(rs.getObject("te"));
-        assertNull(rs.getTime("te"));
-
-        assertFalse(rs.next());
-        rs.close();
-        stmt.close();
-        conn.close();
-    }
-
-    public static void test_evil_date() throws Exception {
-        Connection conn = DriverManager.getConnection(JDBC_URL);
-        Statement stmt = conn.createStatement();
-
-        ResultSet rs = stmt.executeQuery("SELECT '5131-08-05 (BC)'::date d");
-
-        assertTrue(rs.next());
-        assertEquals(rs.getDate("d"), Date.valueOf(LocalDate.of(-5130, 8, 5)));
-
-        assertFalse(rs.next());
-        rs.close();
-        stmt.close();
-        conn.close();
-    }
-
     public static void test_decimal() throws Exception {
         Connection conn = DriverManager.getConnection(JDBC_URL);
         Statement stmt = conn.createStatement();
@@ -2035,35 +1554,6 @@ public class TestDuckDBJDBC {
 
         rs.close();
         conn.close();
-    }
-
-    public static void test_time_tz() throws Exception {
-        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement s = conn.createStatement()) {
-            s.execute("set timezone = 'UTC'");
-            s.executeUpdate("create table t (i time with time zone)");
-            try (ResultSet rs = conn.getMetaData().getColumns(null, "%", "t", "i");) {
-                rs.next();
-
-                assertEquals(rs.getString("TYPE_NAME"), "TIME WITH TIME ZONE");
-                assertEquals(rs.getInt("DATA_TYPE"), Types.TIME_WITH_TIMEZONE);
-            }
-
-            s.execute(
-                "INSERT INTO t VALUES ('01:01:00'), ('01:02:03+12:30:45'), ('04:05:06-03:10'), ('07:08:09+15:59:59');");
-            try (ResultSet rs = s.executeQuery("SELECT * FROM t")) {
-                rs.next();
-                assertEquals(rs.getObject(1), OffsetTime.of(LocalTime.of(1, 1), ZoneOffset.UTC));
-                rs.next();
-                assertEquals(rs.getObject(1),
-                             OffsetTime.of(LocalTime.of(1, 2, 3), ZoneOffset.ofHoursMinutesSeconds(12, 30, 45)));
-                rs.next();
-                assertEquals(rs.getObject(1),
-                             OffsetTime.of(LocalTime.of(4, 5, 6), ZoneOffset.ofHoursMinutesSeconds(-3, -10, 0)));
-                rs.next();
-                assertEquals(rs.getObject(1),
-                             OffsetTime.of(LocalTime.of(7, 8, 9), ZoneOffset.ofHoursMinutesSeconds(15, 59, 59)));
-            }
-        }
     }
 
     public static void test_get_tables_with_current_catalog() throws Exception {
@@ -3139,20 +2629,6 @@ public class TestDuckDBJDBC {
         String query = "SELECT ($1 || $2)";
         conn.prepareStatement(query);
         assertTrue(true);
-    }
-
-    public static void test_bug532_timestamp() throws Exception {
-        Connection conn = DriverManager.getConnection(JDBC_URL);
-        Statement stmt = conn.createStatement();
-
-        ResultSet rs;
-
-        stmt.execute("CREATE TABLE t0(c0 DATETIME);");
-        stmt.execute("INSERT INTO t0 VALUES(DATE '1-1-1');");
-        rs = stmt.executeQuery("SELECT t0.c0 FROM t0; ");
-
-        rs.next();
-        rs.getObject(1);
     }
 
     public static void test_bug966_typeof() throws Exception {
@@ -4602,6 +4078,26 @@ public class TestDuckDBJDBC {
         }
     }
 
+    public static void test_set_streams() throws Exception {
+        try (Connection connection = DriverManager.getConnection(JDBC_URL);
+             PreparedStatement ps = connection.prepareStatement("select ?::VARCHAR")) {
+
+            String helloEn = "Hello";
+            ps.setAsciiStream(1, new ByteArrayInputStream(helloEn.getBytes(US_ASCII)), 4);
+            try (ResultSet rs = ps.executeQuery()) {
+                rs.next();
+                assertEquals(helloEn.substring(0, 4), rs.getString(1));
+            }
+
+            String helloBg = "\u0417\u0434\u0440\u0430\u0432\u0435\u0439\u0442\u0435";
+            ps.setCharacterStream(1, new StringReader(helloBg), 7);
+            try (ResultSet rs = ps.executeQuery()) {
+                rs.next();
+                assertEquals(helloBg.substring(0, 7), rs.getString(1));
+            }
+        }
+    }
+
     public static void test_case_insensitivity() throws Exception {
         try (Connection connection = DriverManager.getConnection("jdbc:duckdb:")) {
             try (Statement s = connection.createStatement()) {
@@ -4886,6 +4382,21 @@ public class TestDuckDBJDBC {
         }
     }
 
+    public static void test_execute_autogen_keys() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE tab1 (col1 INT)");
+
+            // check that the following method do not throw SQLFeatureNotSupportedException
+            String sql = "INSERT INTO tab1 VALUES (42)";
+            assertFalse(stmt.execute(sql, Statement.NO_GENERATED_KEYS));
+            assertFalse(stmt.execute(sql, new int[0]));
+            assertFalse(stmt.execute(sql, new String[0]));
+            assertEquals(stmt.executeUpdate(sql, Statement.NO_GENERATED_KEYS), 1);
+            assertEquals(stmt.executeUpdate(sql, new int[0]), 1);
+            assertEquals(stmt.executeUpdate(sql, new String[0]), 1);
+        }
+    }
+
     public static void main(String[] args) throws Exception {
         String arg1 = args.length > 0 ? args[0] : "";
         final int statusCode;
@@ -4895,7 +4406,7 @@ public class TestDuckDBJDBC {
         } else {
             // extension installation fails on CI, Spatial test is temporary disabled
             statusCode = runTests(args, TestDuckDBJDBC.class, TestExtensionTypes.class /*, TestSpatial.class */,
-                                  TestParameterMetadata.class, TestClosure.class);
+                                  TestParameterMetadata.class, TestClosure.class, TestTimestamp.class);
         }
         System.exit(statusCode);
     }

--- a/src/test/java/org/duckdb/TestTimestamp.java
+++ b/src/test/java/org/duckdb/TestTimestamp.java
@@ -1,0 +1,555 @@
+package org.duckdb;
+
+import static org.duckdb.TestDuckDBJDBC.JDBC_URL;
+import static org.duckdb.test.Assertions.*;
+import static org.duckdb.test.Assertions.assertFalse;
+
+import java.sql.*;
+import java.time.*;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.Locale;
+import java.util.TimeZone;
+
+public class TestTimestamp {
+
+    public static void test_timestamp_ms() throws Exception {
+        String expectedString = "2022-08-17 12:11:10.999";
+        String sql = "SELECT '2022-08-17T12:11:10.999'::TIMESTAMP_MS as ts_ms";
+        assert_timestamp_match(sql, expectedString, "TIMESTAMP_MS");
+    }
+
+    public static void test_timestamp_ns() throws Exception {
+        String expectedString = "2022-08-17 12:11:10.999999999";
+        String sql = "SELECT '2022-08-17T12:11:10.999999999'::TIMESTAMP_NS as ts_ns";
+        assert_timestamp_match(sql, expectedString, "TIMESTAMP_NS");
+    }
+
+    public static void test_timestamp_s() throws Exception {
+        String expectedString = "2022-08-17 12:11:10";
+        String sql = "SELECT '2022-08-17T12:11:10'::TIMESTAMP_S as ts_s";
+        assert_timestamp_match(sql, expectedString, "TIMESTAMP_S");
+    }
+
+    private static void assert_timestamp_match(String fetchSql, String expectedString, String expectedTypeName)
+        throws Exception {
+        String originalTzProperty = System.getProperty("user.timezone");
+        TimeZone originalTz = TimeZone.getDefault();
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+            System.setProperty("user.timezone", "UTC");
+            try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery(fetchSql)) {
+                assertTrue(rs.next());
+                Timestamp actual = rs.getTimestamp(1);
+
+                Timestamp expected = Timestamp.valueOf(expectedString);
+
+                assertEquals(expected.getTime(), actual.getTime());
+                assertEquals(expected.getNanos(), actual.getNanos());
+
+                assertEquals(Types.TIMESTAMP, rs.getMetaData().getColumnType(1));
+                assertEquals(expectedTypeName, rs.getMetaData().getColumnTypeName(1));
+            }
+        } finally {
+            TimeZone.setDefault(originalTz);
+            System.setProperty("user.timezone", originalTzProperty);
+        }
+    }
+
+    public static void test_timestamp_tz() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE t (id INT, t1 TIMESTAMPTZ)");
+            stmt.execute("INSERT INTO t (id, t1) VALUES (1, '2022-01-01T12:11:10+02')");
+            stmt.execute("INSERT INTO t (id, t1) VALUES (2, '2022-01-01T12:11:10Z')");
+
+            PreparedStatement ps = conn.prepareStatement("INSERT INTO T (id, t1) VALUES (?, ?)");
+
+            OffsetDateTime odt1 = OffsetDateTime.of(2020, 10, 7, 13, 15, 7, 12345, ZoneOffset.ofHours(7));
+            OffsetDateTime odt1Rounded = OffsetDateTime.of(2020, 10, 7, 13, 15, 7, 12000, ZoneOffset.ofHours(7));
+            OffsetDateTime odt2 = OffsetDateTime.of(1878, 10, 2, 1, 15, 7, 12345, ZoneOffset.ofHours(-5));
+            OffsetDateTime odt2Rounded = OffsetDateTime.of(1878, 10, 2, 1, 15, 8, 13000, ZoneOffset.ofHours(-5));
+            OffsetDateTime odt3 = OffsetDateTime.of(2022, 1, 1, 12, 11, 10, 0, ZoneOffset.ofHours(2));
+            OffsetDateTime odt4 = OffsetDateTime.of(2022, 1, 1, 12, 11, 10, 0, ZoneOffset.ofHours(0));
+            OffsetDateTime odt5 = OffsetDateTime.of(1900, 11, 27, 23, 59, 59, 0, ZoneOffset.ofHours(1));
+
+            ps.setObject(1, 3);
+            ps.setObject(2, odt1);
+            ps.execute();
+            ps.setObject(1, 4);
+            ps.setObject(2, odt5, Types.TIMESTAMP_WITH_TIMEZONE);
+            ps.execute();
+            ps.setObject(1, 5);
+            ps.setObject(2, odt2);
+            ps.execute();
+
+            try (ResultSet rs = stmt.executeQuery("SELECT * FROM t ORDER BY id")) {
+                ResultSetMetaData meta = rs.getMetaData();
+                rs.next();
+                assertTrue(rs.getObject(2, OffsetDateTime.class).isEqual(odt3));
+                rs.next();
+                assertEquals(rs.getObject(2, OffsetDateTime.class), odt4);
+                rs.next();
+                assertTrue(rs.getObject(2, OffsetDateTime.class).isEqual(odt1Rounded));
+                rs.next();
+                assertTrue(rs.getObject(2, OffsetDateTime.class).isEqual(odt5));
+                rs.next();
+                assertTrue(rs.getObject(2, OffsetDateTime.class).isEqual(odt2Rounded));
+                assertTrue(((OffsetDateTime) rs.getObject(2)).isEqual(odt2Rounded));
+
+                // Metadata tests
+                assertEquals(Types.TIMESTAMP_WITH_TIMEZONE,
+                             (meta.unwrap(DuckDBResultSetMetaData.class)
+                                  .type_to_int(DuckDBColumnType.TIMESTAMP_WITH_TIME_ZONE)));
+                assertTrue(OffsetDateTime.class.getName().equals(meta.getColumnClassName(2)));
+            }
+        }
+    }
+
+    public static void test_timestamp_as_long() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement()) {
+
+            stmt.execute("CREATE TABLE t (id INT, t1 TIMESTAMP)");
+            stmt.execute("INSERT INTO t (id, t1) VALUES (1, '2022-01-01T12:11:10')");
+            stmt.execute("INSERT INTO t (id, t1) VALUES (2, '2022-01-01T12:11:11')");
+
+            try (ResultSet rs = stmt.executeQuery("SELECT * FROM t ORDER BY id")) {
+                rs.next();
+                assertEquals(rs.getLong(2), 1641039070000000L);
+                rs.next();
+                assertEquals(rs.getLong(2), 1641039071000000L);
+            }
+        }
+    }
+
+    public static void test_timestamptz_as_long() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement()) {
+
+            stmt.execute("SET CALENDAR='gregorian'");
+            stmt.execute("SET TIMEZONE='America/Los_Angeles'");
+            stmt.execute("CREATE TABLE t (id INT, t1 TIMESTAMPTZ)");
+            stmt.execute("INSERT INTO t (id, t1) VALUES (1, '2022-01-01T12:11:10Z')");
+            stmt.execute("INSERT INTO t (id, t1) VALUES (2, '2022-01-01T12:11:11Z')");
+
+            try (ResultSet rs = stmt.executeQuery("SELECT * FROM t ORDER BY id")) {
+                rs.next();
+                assertEquals(rs.getLong(2), 1641039070000000L);
+                rs.next();
+                assertEquals(rs.getLong(2), 1641039071000000L);
+            }
+        }
+    }
+
+    public static void test_consecutive_timestamps() throws Exception {
+        long expected = 986860800000L;
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement()) {
+            try (ResultSet rs = stmt.executeQuery(
+                     "select range from range(TIMESTAMP '2001-04-10', TIMESTAMP '2001-04-11', INTERVAL 30 MINUTE)")) {
+                Calendar cal = GregorianCalendar.getInstance();
+                cal.setTimeZone(TimeZone.getTimeZone("UTC"));
+                while (rs.next()) {
+                    Timestamp actual = rs.getTimestamp(1, cal);
+                    assertEquals(expected, actual.getTime());
+                    expected += 30 * 60 * 1_000;
+                }
+            }
+        }
+    }
+
+    public static void test_timestamp_getters() throws Exception {
+        TimeZone defaultTimeZone = TimeZone.getDefault();
+        TimeZone activeTimeZone = TimeZone.getTimeZone("Europe/Sofia");
+        TimeZone.setDefault(activeTimeZone);
+        try {
+            try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement s = conn.createStatement()) {
+                try (ResultSet rs = s.executeQuery(
+                         "SELECT '2020-01-01 01:23:45.678901 Australia/Darwin'::TIMESTAMP WITH TIME ZONE")) {
+                    rs.next();
+                    assertEquals("2019-12-31 17:53:45.678901", rs.getTimestamp(1).toString());
+                    assertEquals(1577807625678L, rs.getTimestamp(1).getTime());
+                    assertEquals("2019-12-31", rs.getDate(1).toString());
+                    assertEquals("Tue Dec 31 00:00:00 EET 2019",
+                                 new java.util.Date(rs.getDate(1).getTime()).toString());
+                    assertEquals("17:53:45", rs.getTime(1).toString());
+                    assertEquals("2019-12-31T17:53:45.678901", rs.getTimestamp(1).toLocalDateTime().toString());
+                    Calendar cal = GregorianCalendar.getInstance();
+                    cal.setTimeZone(TimeZone.getTimeZone("America/New_York"));
+                    assertEquals("2019-12-31 10:53:45.678901", rs.getTimestamp(1, cal).toString());
+                    assertEquals(1577782425678L, rs.getTimestamp(1, cal).getTime());
+                }
+                try (ResultSet rs =
+                         s.executeQuery("SELECT '2020-01-01 01:23:45.678901'::TIMESTAMP WITHOUT TIME ZONE")) {
+                    rs.next();
+                    assertEquals("2020-01-01 01:23:45.678901", rs.getTimestamp(1).toString());
+                    assertEquals(1577834625678L, rs.getTimestamp(1).getTime());
+                    Calendar cal = GregorianCalendar.getInstance();
+                    cal.setTimeZone(TimeZone.getTimeZone("America/New_York"));
+                    assertEquals("2020-01-01 08:23:45.678901", rs.getTimestamp(1, cal).toString());
+                    assertEquals(1577859825678L, rs.getTimestamp(1, cal).getTime());
+                }
+            }
+        } finally {
+            TimeZone.setDefault(defaultTimeZone);
+        }
+    }
+
+    public static void test_duckdb_timestamp() throws Exception {
+        duckdb_timestamp_test();
+
+        // Store default time zone
+        TimeZone defaultTZ = TimeZone.getDefault();
+
+        // Test with different time zones
+        TimeZone.setDefault(TimeZone.getTimeZone("America/Lima"));
+        duckdb_timestamp_test();
+
+        // Test with different time zones
+        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Berlin"));
+        duckdb_timestamp_test();
+
+        // Restore default time zone
+        TimeZone.setDefault(defaultTZ);
+    }
+
+    public static void duckdb_timestamp_test() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("CREATE TABLE a (ts TIMESTAMP)");
+
+                // Generate tests without database
+                Timestamp ts0 = Timestamp.valueOf("1970-01-01 00:00:00");
+                Timestamp ts1 = Timestamp.valueOf("2021-07-29 21:13:11");
+                Timestamp ts2 = Timestamp.valueOf("2021-07-29 21:13:11.123456");
+                Timestamp ts3 = Timestamp.valueOf("1921-07-29 21:13:11");
+                Timestamp ts4 = Timestamp.valueOf("1921-07-29 21:13:11.123456");
+
+                Timestamp cts0 = new DuckDBTimestamp(ts0).toSqlTimestamp();
+                Timestamp cts1 = new DuckDBTimestamp(ts1).toSqlTimestamp();
+                Timestamp cts2 = new DuckDBTimestamp(ts2).toSqlTimestamp();
+                Timestamp cts3 = new DuckDBTimestamp(ts3).toSqlTimestamp();
+                Timestamp cts4 = new DuckDBTimestamp(ts4).toSqlTimestamp();
+
+                assertTrue(ts0.getTime() == cts0.getTime());
+                assertTrue(ts0.compareTo(cts0) == 0);
+                assertTrue(ts1.getTime() == cts1.getTime());
+                assertTrue(ts1.compareTo(cts1) == 0);
+                assertTrue(ts2.getTime() == cts2.getTime());
+                assertTrue(ts2.compareTo(cts2) == 0);
+                assertTrue(ts3.getTime() == cts3.getTime());
+                assertTrue(ts3.compareTo(cts3) == 0);
+                assertTrue(ts4.getTime() == cts4.getTime());
+                assertTrue(ts4.compareTo(cts4) == 0);
+
+                DuckDBTimestamp dts4 = new DuckDBTimestamp(ts1);
+                assertTrue(dts4.toSqlTimestamp().compareTo(ts1) == 0);
+                DuckDBTimestamp dts5 = new DuckDBTimestamp(ts2);
+                assertTrue(dts5.toSqlTimestamp().compareTo(ts2) == 0);
+
+                // Insert and read a timestamp
+                stmt.execute("INSERT INTO a (ts) VALUES ('2005-11-02 07:59:58')");
+                try (ResultSet rs = stmt.executeQuery("SELECT * FROM a")) {
+                    assertTrue(rs.next());
+                    assertEquals(rs.getObject("ts"), Timestamp.valueOf("2005-11-02 07:59:58"));
+                    assertEquals(rs.getTimestamp("ts"), Timestamp.valueOf("2005-11-02 07:59:58"));
+                }
+            }
+
+            try (PreparedStatement ps = conn.prepareStatement("SELECT COUNT(ts) FROM a WHERE ts = ?")) {
+                ps.setTimestamp(1, Timestamp.valueOf("2005-11-02 07:59:58"));
+                try (ResultSet rs2 = ps.executeQuery()) {
+                    assertTrue(rs2.next());
+                    assertEquals(rs2.getInt(1), 1);
+                }
+            }
+
+            try (PreparedStatement ps = conn.prepareStatement("SELECT COUNT(ts) FROM a WHERE ts = ?")) {
+                ps.setObject(1, Timestamp.valueOf("2005-11-02 07:59:58"));
+                try (ResultSet rs3 = ps.executeQuery()) {
+                    assertTrue(rs3.next());
+                    assertEquals(rs3.getInt(1), 1);
+                }
+            }
+
+            try (PreparedStatement ps = conn.prepareStatement("SELECT COUNT(ts) FROM a WHERE ts = ?")) {
+                ps.setObject(1, Timestamp.valueOf("2005-11-02 07:59:58"), Types.TIMESTAMP);
+                ResultSet rs4 = ps.executeQuery();
+                assertTrue(rs4.next());
+                assertEquals(rs4.getInt(1), 1);
+                rs4.close();
+            }
+
+            try (Statement stmt2 = conn.createStatement()) {
+                stmt2.execute("INSERT INTO a (ts) VALUES ('1905-11-02 07:59:58.12345')");
+            }
+            try (PreparedStatement ps = conn.prepareStatement("SELECT COUNT(ts) FROM a WHERE ts = ?")) {
+                ps.setTimestamp(1, Timestamp.valueOf("1905-11-02 07:59:58.12345"));
+                try (ResultSet rs5 = ps.executeQuery()) {
+                    assertTrue(rs5.next());
+                    assertEquals(rs5.getInt(1), 1);
+                }
+            }
+
+            try (PreparedStatement ps = conn.prepareStatement("SELECT ts FROM a WHERE ts = ?")) {
+                ps.setTimestamp(1, Timestamp.valueOf("1905-11-02 07:59:58.12345"));
+                try (ResultSet rs6 = ps.executeQuery()) {
+                    assertTrue(rs6.next());
+                    assertEquals(rs6.getTimestamp(1), Timestamp.valueOf("1905-11-02 07:59:59.12345"));
+                }
+            }
+        }
+    }
+
+    public static void test_duckdb_localdatetime() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement()) {
+
+            stmt.execute("CREATE TABLE x (ts TIMESTAMP)");
+
+            LocalDateTime ldt = LocalDateTime.of(2021, 1, 18, 21, 20, 7);
+
+            try (PreparedStatement ps1 = conn.prepareStatement("INSERT INTO x VALUES (?)")) {
+                ps1.setObject(1, ldt);
+                ps1.execute();
+            }
+
+            try (PreparedStatement ps2 = conn.prepareStatement("SELECT * FROM x"); ResultSet rs2 = ps2.executeQuery()) {
+
+                rs2.next();
+                assertEquals(rs2.getTimestamp(1), rs2.getObject(1, Timestamp.class));
+                assertEquals(rs2.getObject(1, LocalDateTime.class), ldt);
+            }
+        }
+    }
+
+    public static void test_duckdb_localdate() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE x (dt Date)");
+
+            LocalDate ld = LocalDate.of(2024, 7, 22);
+            Date date = Date.valueOf(ld);
+
+            try (PreparedStatement ps1 = conn.prepareStatement("INSERT INTO x VALUES (?)")) {
+                ps1.setObject(1, date);
+                ps1.execute();
+
+                ps1.setObject(1, ld);
+                ps1.execute();
+            }
+
+            try (PreparedStatement ps2 = conn.prepareStatement("SELECT * FROM x"); ResultSet rs2 = ps2.executeQuery()) {
+                rs2.next();
+                assertEquals(rs2.getDate(1), rs2.getObject(1, Date.class));
+                assertEquals(rs2.getObject(1, LocalDate.class), ld);
+                assertEquals(rs2.getObject("dt", LocalDate.class), ld);
+
+                rs2.next();
+                assertEquals(rs2.getDate(1), rs2.getObject(1, Date.class));
+                assertEquals(rs2.getObject(1, LocalDate.class), ld);
+                assertEquals(rs2.getObject("dt", LocalDate.class), ld);
+            }
+        }
+    }
+
+    // Longer, resource intensive test - might be commented out for a quick test run
+    public static void test_lots_of_timestamps() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
+            Timestamp ts = Timestamp.valueOf("1970-01-01 01:01:01");
+
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("CREATE TABLE a (ts TIMESTAMP)");
+                for (long i = 134234533L; i < 13423453300L; i = i + 735127) {
+                    ts.setTime(i);
+                    stmt.execute("INSERT INTO a (ts) VALUES ('" + ts + "')");
+                }
+            }
+
+            for (long i = 134234533L; i < 13423453300L; i = i + 735127) {
+                try (PreparedStatement ps = conn.prepareStatement("SELECT COUNT(ts) FROM a WHERE ts = ?")) {
+                    ps.setTimestamp(1, ts);
+                    try (ResultSet rs = ps.executeQuery()) {
+                        assertTrue(rs.next());
+                        assertEquals(rs.getInt(1), 1);
+                    }
+                }
+            }
+        }
+    }
+
+    public static void test_set_date() throws Exception {
+        TimeZone defaultTimeZone = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Sofia"));
+        try (Connection conn = DriverManager.getConnection(JDBC_URL);
+             PreparedStatement stmt = conn.prepareStatement("SELECT ?::DATE")) {
+
+            try (Statement st = conn.createStatement()) {
+                st.execute("SET TimeZone = 'Europe/Sofia'");
+            }
+
+            // default time zone
+            Date date = Date.valueOf(LocalDate.of(1969, 1, 1));
+            stmt.setDate(1, date);
+            try (ResultSet rs = stmt.executeQuery()) {
+                rs.next();
+                assertEquals(rs.getDate(1), date);
+            }
+
+            // custom time zone
+            stmt.clearParameters();
+            Calendar cal = new GregorianCalendar();
+            cal.setTimeZone(TimeZone.getTimeZone("America/Los_Angeles"));
+            Date dateWithCal = Date.valueOf(LocalDate.of(2000, 1, 1));
+            stmt.setDate(1, dateWithCal, cal);
+            try (ResultSet rs = stmt.executeQuery()) {
+                rs.next();
+                assertEquals(rs.getDate(1), Date.valueOf(LocalDate.of(1999, 12, 31)));
+            }
+        } finally {
+            TimeZone.setDefault(defaultTimeZone);
+        }
+    }
+
+    public static void test_set_time() throws Exception {
+        TimeZone defaultTimeZone = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Sofia"));
+        try (Connection conn = DriverManager.getConnection(JDBC_URL);
+             PreparedStatement stmt = conn.prepareStatement("SELECT ?::TIME")) {
+
+            // default time zone
+            Time time = Time.valueOf(LocalTime.of(12, 40, 0));
+            stmt.setTime(1, time);
+            try (ResultSet rs = stmt.executeQuery()) {
+                rs.next();
+                assertEquals(rs.getTime(1), time);
+            }
+
+            // custom time zone
+            stmt.clearParameters();
+            Calendar cal = new GregorianCalendar();
+            cal.setTimeZone(TimeZone.getTimeZone("America/Los_Angeles"));
+            Time timeWithCal = Time.valueOf(LocalTime.of(0, 0, 0));
+            stmt.setTime(1, timeWithCal, cal);
+            try (ResultSet rs = stmt.executeQuery()) {
+                rs.next();
+                assertEquals(rs.getTime(1), Time.valueOf(LocalTime.of(14, 0, 0)));
+            }
+        } finally {
+            TimeZone.setDefault(defaultTimeZone);
+        }
+    }
+
+    public static void test_set_timestamp() throws Exception {
+        TimeZone defaultTimeZone = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Sofia"));
+        try (Connection conn = DriverManager.getConnection(JDBC_URL);
+             PreparedStatement stmt = conn.prepareStatement("SELECT ?::TIMESTAMP")) {
+
+            // default time zone
+            Timestamp timestamp = Timestamp.valueOf(LocalDateTime.of(2021, 7, 16, 12, 34, 45));
+            stmt.setTimestamp(1, timestamp);
+            try (ResultSet rs = stmt.executeQuery()) {
+                rs.next();
+                assertEquals(rs.getTimestamp(1), timestamp);
+            }
+
+            // custom time zone
+            stmt.clearParameters();
+            Calendar cal = new GregorianCalendar();
+            cal.setTimeZone(TimeZone.getTimeZone("America/Los_Angeles"));
+            Timestamp timestampWithCal = Timestamp.valueOf(LocalDateTime.of(2000, 1, 1, 0, 0, 0));
+            stmt.setTimestamp(1, timestampWithCal, cal);
+            try (ResultSet rs = stmt.executeQuery()) {
+                rs.next();
+                assertEquals(rs.getTimestamp(1), Timestamp.valueOf(LocalDateTime.of(1999, 12, 31, 14, 0, 0)));
+            }
+        } finally {
+            TimeZone.setDefault(defaultTimeZone);
+        }
+    }
+
+    public static void test_calendar_types() throws Exception {
+        //	Nail down the location for test portability.
+        Calendar cal = new GregorianCalendar(TimeZone.getTimeZone("America/Los_Angeles"), Locale.US);
+
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement();
+
+             ResultSet rs = stmt.executeQuery(
+                 "SELECT '2019-11-26 21:11:43.123456'::timestamp ts, '2019-11-26'::date dt, '21:11:00'::time te")) {
+            assertTrue(rs.next());
+            assertEquals(rs.getTimestamp("ts", cal), Timestamp.valueOf("2019-11-27 05:11:43.123456"));
+
+            assertEquals(rs.getDate("dt", cal), Date.valueOf("2019-11-26"));
+
+            assertEquals(rs.getTime("te", cal), Time.valueOf("21:11:00"));
+
+            assertFalse(rs.next());
+        }
+    }
+
+    public static void test_temporal_nulls() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement();
+
+             ResultSet rs = stmt.executeQuery("SELECT NULL::timestamp ts, NULL::date dt, NULL::time te")) {
+            assertTrue(rs.next());
+            assertNull(rs.getObject("ts"));
+            assertNull(rs.getTimestamp("ts"));
+
+            assertNull(rs.getObject("dt"));
+            assertNull(rs.getDate("dt"));
+
+            assertNull(rs.getObject("te"));
+            assertNull(rs.getTime("te"));
+
+            assertFalse(rs.next());
+        }
+    }
+
+    public static void test_evil_date() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT '5131-08-05 (BC)'::date d")) {
+            assertTrue(rs.next());
+            assertEquals(rs.getDate("d"), Date.valueOf(LocalDate.of(-5130, 8, 5)));
+
+            assertFalse(rs.next());
+        }
+    }
+
+    public static void test_time_tz() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement s = conn.createStatement()) {
+            s.execute("set timezone = 'UTC'");
+            s.executeUpdate("create table t (i time with time zone)");
+            try (ResultSet rs = conn.getMetaData().getColumns(null, "%", "t", "i");) {
+                rs.next();
+
+                assertEquals(rs.getString("TYPE_NAME"), "TIME WITH TIME ZONE");
+                assertEquals(rs.getInt("DATA_TYPE"), Types.TIME_WITH_TIMEZONE);
+            }
+
+            s.execute(
+                "INSERT INTO t VALUES ('01:01:00'), ('01:02:03+12:30:45'), ('04:05:06-03:10'), ('07:08:09+15:59:59');");
+            try (ResultSet rs = s.executeQuery("SELECT * FROM t")) {
+                rs.next();
+                assertEquals(rs.getObject(1), OffsetTime.of(LocalTime.of(1, 1), ZoneOffset.UTC));
+                rs.next();
+                assertEquals(rs.getObject(1),
+                             OffsetTime.of(LocalTime.of(1, 2, 3), ZoneOffset.ofHoursMinutesSeconds(12, 30, 45)));
+                rs.next();
+                assertEquals(rs.getObject(1),
+                             OffsetTime.of(LocalTime.of(4, 5, 6), ZoneOffset.ofHoursMinutesSeconds(-3, -10, 0)));
+                rs.next();
+                assertEquals(rs.getObject(1),
+                             OffsetTime.of(LocalTime.of(7, 8, 9), ZoneOffset.ofHoursMinutesSeconds(15, 59, 59)));
+            }
+        }
+    }
+
+    public static void test_bug532_timestamp() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement()) {
+
+            stmt.execute("CREATE TABLE t0(c0 DATETIME);");
+            stmt.execute("INSERT INTO t0 VALUES(DATE '1-1-1');");
+            try (ResultSet rs = stmt.executeQuery("SELECT t0.c0 FROM t0; ")) {
+                rs.next();
+                rs.getObject(1);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This change implements a number of setter methods on `PreparedStatement` that were previously throwing
`SQLFeatureNotSupportedException`.

`set*Stream` group of methods is implemented only for compatibility with existing tools, no actual streaming is used on DB level - full input is read to string/bytes before passing it to DB.

`execute`/`executeUpdate` methods for generated keys are implemented only for cases when generated keys are not requested.

`setTime/Date/Timestamp` methods with `Calendar` (time zone) support are implemented fully following the same approach used before in #166. Also the logic for `setTime` method without `Calendar` is fixed to correctly NOT use default JVM time zone.

Testing: new tests added to cover implemented methods; timestamp tests are moved to separate file and time zone-specific tests are added.

Fixes: #195