### PR TITLE
Run executeBatch in a single transaction

### DIFF
--- a/src/main/java/org/duckdb/DuckDBConnection.java
+++ b/src/main/java/org/duckdb/DuckDBConnection.java
@@ -40,8 +40,8 @@ public final class DuckDBConnection implements java.sql.Connection {
     final LinkedHashSet<DuckDBPreparedStatement> preparedStatements = new LinkedHashSet<>();
     volatile boolean closing = false;
 
-    boolean autoCommit = true;
-    boolean transactionRunning;
+    volatile boolean autoCommit = true;
+    volatile boolean transactionRunning;
     final String url;
     private final boolean readOnly;
 


### PR DESCRIPTION
This change makes `executeBatch()` method to be run in a single transaction when auto-commit is enabled. When auto-commit is disabled, the logic remains the same as before.

Testing: new tests added to check auto-commit and rollback behaviour of `executeBatch()`.