### PR TITLE
Enable extension tests on CI

### DIFF
--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -3491,9 +3491,8 @@ public class TestDuckDBJDBC {
             Class<?> clazz = Class.forName("org.duckdb." + arg1);
             statusCode = runTests(new String[0], clazz);
         } else {
-            // extension installation fails on CI, Spatial test is temporary disabled
             statusCode = runTests(args, TestDuckDBJDBC.class, TestBatch.class, TestClosure.class,
-                                  TestExtensionTypes.class /*, TestSpatial.class */, TestParameterMetadata.class,
+                                  TestExtensionTypes.class, TestSpatial.class, TestParameterMetadata.class,
                                   TestPrepare.class, TestResults.class, TestTimestamp.class);
         }
         System.exit(statusCode);


### PR DESCRIPTION
This change enables Spatial extension tests on GitHub CI runs. With recent improvements in DuckDB engine vendoring process it is expected that JDBC builds can only be done with engine version for that the full set of prebuilt extensions is available, thus `INSTALL spatial` must work.