### PR TITLE
Support auto-initializing DuckLake

### DIFF
--- a/src/main/java/org/duckdb/DuckDBDriver.java
+++ b/src/main/java/org/duckdb/DuckDBDriver.java
@@ -1,18 +1,24 @@
 package org.duckdb;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.DriverPropertyInfo;
-import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
+import java.sql.*;
 import java.util.Properties;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 public class DuckDBDriver implements java.sql.Driver {
 
     public static final String DUCKDB_READONLY_PROPERTY = "duckdb.read_only";
     public static final String DUCKDB_USER_AGENT_PROPERTY = "custom_user_agent";
     public static final String JDBC_STREAM_RESULTS = "jdbc_stream_results";
+
+    private static final String DUCKDB_URL_PREFIX = "jdbc:duckdb:";
+
+    private static final String DUCKLAKE_OPTION = "ducklake";
+    private static final String DUCKLAKE_ALIAS_OPTION = "ducklake_alias";
+    private static final Pattern DUCKLAKE_ALIAS_OPTION_PATTERN = Pattern.compile("[a-zA-Z0-9_]+");
+    private static final String DUCKLAKE_URL_PREFIX = "ducklake:";
+    private static final ReentrantLock DUCKLAKE_INIT_LOCK = new ReentrantLock();
 
     static {
         try {
@@ -45,11 +51,18 @@ public class DuckDBDriver implements java.sql.Driver {
         // to be established.
         info.remove("path");
 
-        return DuckDBConnection.newConnection(url, read_only, info);
+        String ducklake = removeOption(info, DUCKLAKE_OPTION);
+        String ducklakeAlias = removeOption(info, DUCKLAKE_ALIAS_OPTION);
+
+        Connection conn = DuckDBConnection.newConnection(url, read_only, info);
+
+        initDucklake(conn, url, ducklake, ducklakeAlias);
+
+        return conn;
     }
 
     public boolean acceptsURL(String url) throws SQLException {
-        return url.startsWith("jdbc:duckdb:");
+        return url.startsWith(DUCKDB_URL_PREFIX);
     }
 
     public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
@@ -71,5 +84,49 @@ public class DuckDBDriver implements java.sql.Driver {
 
     public Logger getParentLogger() throws SQLFeatureNotSupportedException {
         throw new SQLFeatureNotSupportedException("no logger");
+    }
+
+    private static void initDucklake(Connection conn, String url, String ducklake, String ducklakeAlias)
+        throws SQLException {
+        if (null == ducklake) {
+            return;
+        }
+        DUCKLAKE_INIT_LOCK.lock();
+        try {
+            String attachQuery = createAttachQuery(ducklake, ducklakeAlias);
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("INSTALL ducklake");
+                stmt.execute("LOAD ducklake");
+                stmt.execute(attachQuery);
+                if (null != ducklakeAlias) {
+                    stmt.execute("USE " + ducklakeAlias);
+                }
+            }
+        } finally {
+            DUCKLAKE_INIT_LOCK.unlock();
+        }
+    }
+
+    private static String createAttachQuery(String ducklake, String ducklakeAlias) throws SQLException {
+        ducklake = ducklake.replaceAll("'", "''");
+        if (!ducklake.startsWith(DUCKLAKE_URL_PREFIX)) {
+            ducklake = DUCKLAKE_URL_PREFIX + ducklake;
+        }
+        String query = "ATTACH IF NOT EXISTS '" + ducklake + "'";
+        if (null != ducklakeAlias) {
+            if (!DUCKLAKE_ALIAS_OPTION_PATTERN.matcher(ducklakeAlias).matches()) {
+                throw new SQLException("Invalid DuckLake alias specified: " + ducklakeAlias);
+            }
+            query += " AS " + ducklakeAlias;
+        }
+        return query;
+    }
+
+    private static String removeOption(Properties props, String opt) {
+        Object obj = props.remove(opt);
+        if (null != obj) {
+            return obj.toString();
+        }
+        return null;
     }
 }


### PR DESCRIPTION
There is a usability gap with using DuckLake with JDBC, when a connection must be opened first and then the following statement must be executed:

```
ATTACH 'ducklake:...'
```

Executing this additional `ATTACH` step, when accessing DuckLake from GUI tools or from high-level engines like Spark, is cumbersome and may require non-trivial configuration.

This change adds two new connection properties:

1. `ducklake`: the `database-path` parameter to pass to `ATTACH '<database-path>'`.

Value examples:

```
/path/to/lake1.db
sqlite:/path/to/lake1.db
postgres:postgresql://user:pwd@127.0.0.1:5432/lake1
```

If `ducklake:` prefix to the value of this option is not specified - it is added automatically.

Before running the `ATTACH` it also runs:

```
INSTALL ducklake
LOAD ducklake
```

2. `ducklake_alias`: the `database-alias` parameter to pass to `ATTACH '<database-path>' AS <database-alias>`.

This is to allow to override auto-detected DuckLake catalog name in cases when `database-path` has long naming or include UUIDs.

After the connection is established it also runs `USE <database-alias>`.

Testing: test coverage is pending, DuckLake extension is not yet available in the `main` branch.