### PR TITLE
Support disabling auto-commit mode in properties

### DIFF
--- a/src/main/java/org/duckdb/JdbcUtils.java
+++ b/src/main/java/org/duckdb/JdbcUtils.java
@@ -1,8 +1,12 @@
 package org.duckdb;
 
 import java.sql.SQLException;
+import java.util.Properties;
 
 final class JdbcUtils {
+
+    private JdbcUtils() {
+    }
 
     @SuppressWarnings("unchecked")
     static <T> T unwrap(Object obj, Class<T> iface) throws SQLException {
@@ -12,6 +16,25 @@ final class JdbcUtils {
         return (T) obj;
     }
 
-    private JdbcUtils() {
+    static String removeOption(Properties props, String opt) {
+        Object obj = props.remove(opt);
+        if (null != obj) {
+            return obj.toString().trim();
+        }
+        return null;
+    }
+
+    static boolean isStringTruish(String val, boolean defaultVal) throws SQLException {
+        if (null == val) {
+            return defaultVal;
+        }
+        String valLower = val.toLowerCase().trim();
+        if (valLower.equals("true") || valLower.equals("1") || valLower.equals("yes") || valLower.equals("on")) {
+            return true;
+        }
+        if (valLower.equals("false") || valLower.equals("0") || valLower.equals("no") || valLower.equals("off")) {
+            return false;
+        }
+        throw new SQLException("Invalid boolean option value: " + val);
     }
 }

--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -3504,6 +3504,42 @@ public class TestDuckDBJDBC {
         }
     }
 
+    public static void test_auto_commit_option() throws Exception {
+        Properties config = new Properties();
+
+        try (Connection conn = DriverManager.getConnection(JDBC_URL, config)) {
+            assertTrue(conn.getAutoCommit());
+        }
+
+        config.put(DuckDBDriver.JDBC_AUTO_COMMIT, true);
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL, config).unwrap(DuckDBConnection.class)) {
+            assertTrue(conn.getAutoCommit());
+
+            try (Connection dup = conn.duplicate()) {
+                assertTrue(dup.getAutoCommit());
+            }
+        }
+
+        config.put(DuckDBDriver.JDBC_AUTO_COMMIT, false);
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL, config).unwrap(DuckDBConnection.class)) {
+            assertFalse(conn.getAutoCommit());
+
+            try (Connection dup = conn.duplicate()) {
+                assertFalse(dup.getAutoCommit());
+            }
+        }
+
+        config.put(DuckDBDriver.JDBC_AUTO_COMMIT, "on");
+        try (Connection conn = DriverManager.getConnection(JDBC_URL, config)) {
+            assertTrue(conn.getAutoCommit());
+        }
+
+        config.put(DuckDBDriver.JDBC_AUTO_COMMIT, "off");
+        try (Connection conn = DriverManager.getConnection(JDBC_URL, config)) {
+            assertFalse(conn.getAutoCommit());
+        }
+    }
+
     public static void main(String[] args) throws Exception {
         String arg1 = args.length > 0 ? args[0] : "";
         final int statusCode;


### PR DESCRIPTION
JDBC spec requires the driver to have `autoCommit` enabled on newly created connections. Changing `autoCommit` using `conn#setAutoCommit()` may be not convenient in some environments with limited access to Java API (e.g. Spark SQL).

This change adds a new `jdbc_auto_commit` connection property that allows to create connections with `autoCommit` disabled.

Testing: new test added to check that property is effective and that the default mode is unchanged.