### PR TITLE
Support connection properties in URL

### DIFF
--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -3540,6 +3540,58 @@ public class TestDuckDBJDBC {
         }
     }
 
+    public static void test_props_from_url() throws Exception {
+        Properties config = new Properties();
+        config.put("allow_community_extensions", false);
+        config.put("allow_unsigned_extensions", true);
+
+        try (Connection conn = DriverManager.getConnection("jdbc:duckdb:", config);
+             Statement stmt = conn.createStatement()) {
+            try (ResultSet rs = stmt.executeQuery("SELECT current_setting('allow_community_extensions')")) {
+                rs.next();
+                assertEquals(rs.getString(1), "false");
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT current_setting('allow_unsigned_extensions')")) {
+                rs.next();
+                assertEquals(rs.getString(1), "true");
+            }
+        }
+
+        try (Connection conn = DriverManager.getConnection(
+                 "jdbc:duckdb:;allow_community_extensions=true;;allow_unsigned_extensions = false;", config);
+             Statement stmt = conn.createStatement()) {
+            try (ResultSet rs = stmt.executeQuery("SELECT current_setting('allow_community_extensions')")) {
+                rs.next();
+                assertEquals(rs.getString(1), "true");
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT current_setting('allow_unsigned_extensions')")) {
+                rs.next();
+                assertEquals(rs.getString(1), "false");
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT current_catalog()")) {
+                rs.next();
+                assertEquals(rs.getString(1), "memory");
+            }
+        }
+
+        try (Connection conn =
+                 DriverManager.getConnection("jdbc:duckdb:test1.db;allow_community_extensions=true;", config);
+             Statement stmt = conn.createStatement()) {
+            try (ResultSet rs = stmt.executeQuery("SELECT current_setting('allow_community_extensions')")) {
+                rs.next();
+                assertEquals(rs.getString(1), "true");
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT current_catalog()")) {
+                rs.next();
+                assertEquals(rs.getString(1), "test1");
+            }
+        }
+
+        assertThrows(
+            () -> { DriverManager.getConnection("jdbc:duckdb:;allow_unsigned_extensions"); }, SQLException.class);
+        assertThrows(() -> { DriverManager.getConnection("jdbc:duckdb:;foo=bar"); }, SQLException.class);
+    }
+
     public static void main(String[] args) throws Exception {
         String arg1 = args.length > 0 ? args[0] : "";
         final int statusCode;


### PR DESCRIPTION
This change adds support for specifying connection properties as part of the connection string itself. It is intended to be used in cases, when `Properties` map is passed by some tool that does not allow direct access to it, and some of these `Properties` values need to be overridden.

Properties in URL are accepted in `key=value` format, `;` is used as a separator, empty properties are ignored.

URL example: `jdbc:duckdb:;allow_community_extensions=true;;allow_unsigned_extensions = false;`.

Testing: new test added that checks that properties in URL take preference.