### PR TITLE
Use default alias and DB pinning for DuckLake

### DIFF
--- a/src/main/java/org/duckdb/JdbcUtils.java
+++ b/src/main/java/org/duckdb/JdbcUtils.java
@@ -1,6 +1,7 @@
 package org.duckdb;
 
 import static org.duckdb.DuckDBDriver.DUCKDB_URL_PREFIX;
+import static org.duckdb.DuckDBDriver.MEMORY_DB;
 
 import java.sql.SQLException;
 import java.util.Properties;
@@ -19,11 +20,22 @@ final class JdbcUtils {
     }
 
     static String removeOption(Properties props, String opt) {
+        return removeOption(props, opt, null);
+    }
+
+    static String removeOption(Properties props, String opt, String defaultVal) {
         Object obj = props.remove(opt);
         if (null != obj) {
             return obj.toString().trim();
         }
-        return null;
+        return defaultVal;
+    }
+
+    static void setDefaultOptionValue(Properties props, String opt, Object value) {
+        if (props.contains(opt)) {
+            return;
+        }
+        props.put(opt, value);
     }
 
     static boolean isStringTruish(String val, boolean defaultVal) throws SQLException {
@@ -56,9 +68,9 @@ final class JdbcUtils {
         }
         String dbName = shortUrl.substring(DUCKDB_URL_PREFIX.length()).trim();
         if (dbName.length() == 0) {
-            dbName = ":memory:";
+            dbName = MEMORY_DB;
         }
-        if (dbName.startsWith("memory:")) {
+        if (dbName.startsWith(MEMORY_DB.substring(1))) {
             dbName = ":" + dbName;
         }
         return dbName;


### PR DESCRIPTION
This PR adds the following changes to DuckLake init:

 - if `ducklake_alias` option is not specified, then default value `ducklake` is used for it
 - when default URL `jdbc:duckdb:` or explicit memory URL `jdbc:duckdb:memory:` is used, then this URL is changed to `jdbc:duckdb:memory:ducklakemem` to be able to share this DB across multiple connections
 - DB pinning is enabled automatically (unless disabled by user)
 - Result set streaming is enabeld automatically (unless disabled by user)
 - DuckLake initialization is done only once for each DB (and each DuckLake path), `ATTACH IF NOT EXISTS` call is changed to `ATTACH`

Testing: test coverage pending, DuckLake is not yet available in `main` branch.