### PR TITLE
Fix deadlock when fetching next chunk

### DIFF
--- a/src/main/java/org/duckdb/DuckDBConnection.java
+++ b/src/main/java/org/duckdb/DuckDBConnection.java
@@ -129,7 +129,7 @@ public final class DuckDBConnection implements java.sql.Connection {
                 return;
             }
 
-            // Mark this instance as 'closing' to skip untrack call in
+            // Mark this instance as 'closing' to skip untrack logic in
             // prepared statements, that requires connection lock and can
             // cause a deadlock when the statement closure is caused by the
             // connection interrupt called by us.

--- a/src/main/java/org/duckdb/DuckDBPreparedStatement.java
+++ b/src/main/java/org/duckdb/DuckDBPreparedStatement.java
@@ -361,7 +361,7 @@ public class DuckDBPreparedStatement implements PreparedStatement {
 
                 // Untrack prepared statement from parent connection,
                 // if 'closing' flag is set it means that the parent connection itself
-                // is being closed and we don't need to call untrack from the statement.
+                // is being closed and we don't need to untrack this instance from the statement.
                 if (!conn.closing) {
                     conn.connRefLock.lock();
                     try {

--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -3454,7 +3454,7 @@ public class TestDuckDBJDBC {
                 @Override
                 public QueryProgress call() throws Exception {
                     try {
-                        Thread.sleep(1000);
+                        Thread.sleep(1500);
                         QueryProgress qp = stmt.getQueryProgress();
                         stmt.cancel();
                         return qp;


### PR DESCRIPTION
When connection is being closed, it closes all statements and all result sets on these statements. All this is done while holding connection lock.

When fetching next chunk, result set needs to take both result set and connection locks. Because of the wrong order of taking these locks, concurrent `close()` call on result set, initiated from `Connection#close()` was causing a deadlock.

This change reorders locks in `ResultSet#fetchChunk()` to fix this.

Testing: new test added that reproduces the deadlock reliably (may need to raise the number of iterations).

Fixes: #241