### PR TITLE
Implement getPropertyInfo method for config list

### DIFF
--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -3644,6 +3644,18 @@ public class TestDuckDBJDBC {
         DriverManager.getConnection(memUrl, config).close();
     }
 
+    public static void test_driver_property_info() throws Exception {
+        Driver driver = DriverManager.getDriver(JDBC_URL);
+        DriverPropertyInfo[] dpis = driver.getPropertyInfo(JDBC_URL, null);
+        for (DriverPropertyInfo dpi : dpis) {
+            assertNotNull(dpi.name);
+            assertNotNull(dpi.value);
+            assertNotNull(dpi.description);
+        }
+        assertNotNull(dpis);
+        assertTrue(dpis.length > 0);
+    }
+
     public static void main(String[] args) throws Exception {
         String arg1 = args.length > 0 ? args[0] : "";
         final int statusCode;


### PR DESCRIPTION
`Driver#getPropertyInfo()` method allows external tools to list configuration options suppored by the DB. This method is pretty obscure and unlikely to be useful with many client tools in practice. But a full list of supported options is required anyway to implement a fix to issue #232, and it makes sense to use `getPropertyInfo` for that as a single method for this functionality.

Testing: new test added.