### PR TITLE
Update GH Windows runners

### DIFF
--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -208,7 +208,7 @@ jobs:
 
   java-windows-amd64:
     name: Java Windows (amd64)
-    runs-on: windows-2019
+    runs-on: windows-latest
     needs: java-linux-amd64
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Windows runnner images are changed from `windows-2019` to `windows-latest` due to actions/runner-images#12045.

edit: corrected `windows-2022` to `windows-latest`.