### PR TITLE
Fix vendoring PRs for stable branches

### DIFF
--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -489,7 +489,7 @@ jobs:
         run: |
             # Delete vendoring-${{ github.base_ref }} branch and re-create it for future PRs
             git push --delete origin vendoring-${{ github.base_ref }}
-            git checkout --track origin/main
+            git checkout --track origin/${{ github.base_ref }}
             git pull --ff-only
             git branch vendoring-${{ github.base_ref }}
             git push origin vendoring-${{ github.base_ref }}


### PR DESCRIPTION
Nightly import of DuckDB engine sources ("vendoring") is performed by creating PRs on `vendoring-<branch>` base branches. After the tests are passed the PR is merged and `vendoring-<branch>` is re-created to be used in subsequent imports.

This change fixes the vendoring branch re-creation to place it not always on the `main` branch, but on the correct branch (either `main` or stable one line `v1.3-ossivalis`).