### PR TITLE
Support memory DBs in URL without leading c. (1.3)

### DIFF
--- a/src/main/java/org/duckdb/DuckDBConnection.java
+++ b/src/main/java/org/duckdb/DuckDBConnection.java
@@ -54,6 +54,9 @@ public final class DuckDBConnection implements java.sql.Connection {
         if (db_dir.length() == 0) {
             db_dir = ":memory:";
         }
+        if (db_dir.startsWith("memory:")) {
+            db_dir = ":" + db_dir;
+        }
         ByteBuffer nativeReference = DuckDBNative.duckdb_jdbc_startup(db_dir.getBytes(UTF_8), readOnly, properties);
         return new DuckDBConnection(nativeReference, url, readOnly);
     }

--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -3484,6 +3484,26 @@ public class TestDuckDBJDBC {
         }
     }
 
+    public static void test_memory_colon() throws Exception {
+        try (Connection conn1 = DriverManager.getConnection("jdbc:duckdb::memory:");
+             Statement stmt1 = conn1.createStatement();
+             Connection conn2 = DriverManager.getConnection("jdbc:duckdb:memory:");
+             Statement stmt2 = conn2.createStatement(); Statement stmt22 = conn2.createStatement()) {
+            stmt1.execute("CREATE TABLE tab1(col1 int)");
+            assertThrows(() -> { stmt2.execute("DROP TABLE tab1"); }, SQLException.class);
+            stmt22.execute("CREATE TABLE tab1(col1 int)");
+        }
+        try (Connection conn1 = DriverManager.getConnection("jdbc:duckdb::memory:tag1");
+             Statement stmt1 = conn1.createStatement(); Statement stmt12 = conn1.createStatement();
+             Connection conn2 = DriverManager.getConnection("jdbc:duckdb:memory:tag1");
+             Statement stmt2 = conn2.createStatement()) {
+            stmt1.execute("CREATE TABLE tab1(col1 int)");
+            stmt2.execute("DROP TABLE tab1");
+            assertThrows(() -> { stmt1.execute("DROP TABLE tab1"); }, SQLException.class);
+            stmt12.execute("CREATE TABLE tab1(col1 int)");
+        }
+    }
+
     public static void main(String[] args) throws Exception {
         String arg1 = args.length > 0 ? args[0] : "";
         final int statusCode;


### PR DESCRIPTION
This is a backport of the PR #234 to v1.3-ossivalis stable branch.

Minor change, to allow passing named in-memory connections without double colon prefix. So the following URLs will point to the same in-memory DB:

```
jdbc:duckdb::memory:tag1
jdbc:duckdb:memory:tag1
```

Testing: new test added that check that DB instance cache works correctly with and without second colon in URL.