### PR TITLE
Add support for query timeouts (1.3)

### DIFF
--- a/src/jni/duckdb_java.cpp
+++ b/src/jni/duckdb_java.cpp
@@ -240,9 +240,11 @@ jobject _duckdb_jdbc_execute(JNIEnv *env, jclass, jobject stmt_ref_buf, jobjectA
 
 	res_ref->res = stmt_ref->stmt->Execute(duckdb_params, stream_results);
 	if (res_ref->res->HasError()) {
-		string error_msg = string(res_ref->res->GetError());
+		std::string error_msg = std::string(res_ref->res->GetError());
+		duckdb::ExceptionType error_type = res_ref->res->GetErrorType();
 		res_ref->res = nullptr;
-		ThrowJNI(env, error_msg.c_str());
+		jclass exc_type = duckdb::ExceptionType::INTERRUPT == error_type ? J_SQLTimeoutException : J_SQLException;
+		env->ThrowNew(exc_type, error_msg.c_str());
 		return nullptr;
 	}
 	return env->NewDirectByteBuffer(res_ref.release(), 0);

--- a/src/jni/refs.cpp
+++ b/src/jni/refs.cpp
@@ -18,6 +18,7 @@ jmethodID J_String_getBytes;
 jclass J_Throwable;
 jmethodID J_Throwable_getMessage;
 jclass J_SQLException;
+jclass J_SQLTimeoutException;
 
 jclass J_Bool;
 jclass J_Byte;
@@ -178,6 +179,7 @@ void create_refs(JNIEnv *env) {
 	J_Throwable = make_class_ref(env, "java/lang/Throwable");
 	J_Throwable_getMessage = get_method_id(env, J_Throwable, "getMessage", "()Ljava/lang/String;");
 	J_SQLException = make_class_ref(env, "java/sql/SQLException");
+	J_SQLTimeoutException = make_class_ref(env, "java/sql/SQLTimeoutException");
 
 	J_Bool = make_class_ref(env, "java/lang/Boolean");
 	J_Byte = make_class_ref(env, "java/lang/Byte");

--- a/src/jni/refs.hpp
+++ b/src/jni/refs.hpp
@@ -15,6 +15,7 @@ extern jmethodID J_String_getBytes;
 extern jclass J_Throwable;
 extern jmethodID J_Throwable_getMessage;
 extern jclass J_SQLException;
+extern jclass J_SQLTimeoutException;
 
 extern jclass J_Bool;
 extern jclass J_Byte;

--- a/src/main/java/org/duckdb/DuckDBDriver.java
+++ b/src/main/java/org/duckdb/DuckDBDriver.java
@@ -6,6 +6,8 @@ import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.Properties;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
 import java.util.logging.Logger;
 
 public class DuckDBDriver implements java.sql.Driver {
@@ -14,11 +16,16 @@ public class DuckDBDriver implements java.sql.Driver {
     public static final String DUCKDB_USER_AGENT_PROPERTY = "custom_user_agent";
     public static final String JDBC_STREAM_RESULTS = "jdbc_stream_results";
 
+    static final ScheduledThreadPoolExecutor scheduler;
+
     static {
         try {
             DriverManager.registerDriver(new DuckDBDriver());
+            ThreadFactory tf = r -> new Thread(r, "duckdb-query-cancel-scheduler-thread");
+            scheduler = new ScheduledThreadPoolExecutor(1, tf);
+            scheduler.setRemoveOnCancelPolicy(true);
         } catch (SQLException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -3455,7 +3455,7 @@ public class TestDuckDBJDBC {
                 @Override
                 public QueryProgress call() throws Exception {
                     try {
-                        Thread.sleep(1500);
+                        Thread.sleep(2500);
                         QueryProgress qp = stmt.getQueryProgress();
                         stmt.cancel();
                         return qp;


### PR DESCRIPTION
This is a backport of the PR #247 to `v1.3-ossivalis` stable branch.

This change implements `Statement#setQueryTimeout()` method. It is implemented by scheduling a background task and calling `Statement#cancel()` when timeout expires.

Timeouted statement has the same behaviour as it would be if cancelled manually - `SQLException` is thrown and the statement is closed.

Timeout is applied for all `execute*` calls. For `executeBatch()` it is applied separately for every single query in a batch.

Testing: new test added.

Fixes: #212