### PR TITLE
Support connection properties in URL (1.3)

### DIFF
--- a/src/test/java/org/duckdb/TestBatch.java
+++ b/src/test/java/org/duckdb/TestBatch.java
@@ -249,9 +249,9 @@ public class TestBatch {
     }
 
     public static void test_statement_batch_constraint_violation() throws Exception {
-        Properties config = new Properties();
-        config.put(DuckDBDriver.JDBC_AUTO_COMMIT, false);
-        try (Connection conn = DriverManager.getConnection(JDBC_URL, config)) {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
+            conn.setAutoCommit(false);
+            assertFalse(conn.getAutoCommit());
             assertFalse(conn.getAutoCommit());
             try (Statement stmt = conn.createStatement()) {
                 stmt.execute("CREATE TABLE tab1 (col1 VARCHAR NOT NULL)");
@@ -277,9 +277,8 @@ public class TestBatch {
     }
 
     public static void test_prepared_statement_batch_constraint_violation() throws Exception {
-        Properties config = new Properties();
-        config.put(DuckDBDriver.JDBC_AUTO_COMMIT, false);
-        try (Connection conn = DriverManager.getConnection(JDBC_URL, config)) {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
+            conn.setAutoCommit(false);
             assertFalse(conn.getAutoCommit());
             try (Statement stmt = conn.createStatement()) {
                 stmt.execute("CREATE TABLE tab1 (col1 VARCHAR NOT NULL)");


### PR DESCRIPTION
This is a backport of the PR #237 to `v1.3-ossivalis` stable branch.

This change adds support for specifying connection properties as part of the connection string itself. It is intended to be used in cases, when `Properties` map is passed by some tool that does not allow direct access to it, and some of these `Properties` values need to be overridden.

Properties in URL are accepted in `key=value` format, `;` is used as a separator, empty properties are ignored.

URL example: `jdbc:duckdb:;allow_community_extensions=true;;allow_unsigned_extensions = false;`.

Testing: new test added that checks that properties in URL take preference.