### PR TITLE
Implement getPropertyInfo method for config (1.3)

### DIFF
--- a/src/main/java/org/duckdb/DuckDBDriver.java
+++ b/src/main/java/org/duckdb/DuckDBDriver.java
@@ -1,11 +1,7 @@
 package org.duckdb;
 
 import java.nio.ByteBuffer;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.DriverPropertyInfo;
-import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
+import java.sql.*;
 import java.util.*;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
@@ -87,8 +83,23 @@ public class DuckDBDriver implements java.sql.Driver {
     }
 
     public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
-        DriverPropertyInfo[] ret = {};
-        return ret; // no properties
+        List<DriverPropertyInfo> list = new ArrayList<>();
+        try (Connection conn = DriverManager.getConnection(url, info); Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT name, value, description FROM duckdb_settings()")) {
+            while (rs.next()) {
+                String name = rs.getString(1);
+                String value = rs.getString(2);
+                String description = rs.getString(3);
+                list.add(createDriverPropInfo(name, value, description));
+            }
+        }
+        list.add(createDriverPropInfo(DUCKDB_READONLY_PROPERTY, "", "Set connection to read-only mode"));
+        list.add(createDriverPropInfo(DUCKDB_USER_AGENT_PROPERTY, "", "Custom user agent string"));
+        list.add(createDriverPropInfo(JDBC_STREAM_RESULTS, "", "Enable result set streaming"));
+        list.add(createDriverPropInfo(JDBC_PIN_DB, "",
+                                      "Do not close the DB instance after all connections to it are closed"));
+        list.sort((o1, o2) -> o1.name.compareToIgnoreCase(o2.name));
+        return list.toArray(new DriverPropertyInfo[0]);
     }
 
     public int getMajorVersion() {
@@ -177,6 +188,12 @@ public class DuckDBDriver implements java.sql.Driver {
         } finally {
             pinnedDbRefsLock.unlock();
         }
+    }
+
+    private static DriverPropertyInfo createDriverPropInfo(String name, String value, String description) {
+        DriverPropertyInfo dpi = new DriverPropertyInfo(name, value);
+        dpi.description = description;
+        return dpi;
     }
 
     private static class ParsedProps {

--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -3608,6 +3608,18 @@ public class TestDuckDBJDBC {
         DriverManager.getConnection(memUrl, config).close();
     }
 
+    public static void test_driver_property_info() throws Exception {
+        Driver driver = DriverManager.getDriver(JDBC_URL);
+        DriverPropertyInfo[] dpis = driver.getPropertyInfo(JDBC_URL, null);
+        for (DriverPropertyInfo dpi : dpis) {
+            assertNotNull(dpi.name);
+            assertNotNull(dpi.value);
+            assertNotNull(dpi.description);
+        }
+        assertNotNull(dpis);
+        assertTrue(dpis.length > 0);
+    }
+
     public static void main(String[] args) throws Exception {
         String arg1 = args.length > 0 ? args[0] : "";
         final int statusCode;


### PR DESCRIPTION
This is a backport of the PR #244 to `v1.3-ossivalis` stable branch.

`Driver#getPropertyInfo()` method allows external tools to list configuration options suppored by the DB. This method is pretty obscure and unlikely to be useful with many client tools in practice. But a full list of supported options is required anyway to implement a fix to issue #232, and it makes sense to use `getPropertyInfo` for that as a single method for this functionality.

Testing: new test added.