### PR TITLE
Allow to ignore unsupported connection opts (1.3)

### DIFF
--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -10,6 +10,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.duckdb.DuckDBDriver.DUCKDB_USER_AGENT_PROPERTY;
+import static org.duckdb.DuckDBDriver.JDBC_STREAM_RESULTS;
 import static org.duckdb.DuckDBTimestamp.localDateTimeFromTimestamp;
 import static org.duckdb.test.Assertions.*;
 import static org.duckdb.test.Runner.runTests;
@@ -3618,6 +3619,14 @@ public class TestDuckDBJDBC {
         }
         assertNotNull(dpis);
         assertTrue(dpis.length > 0);
+    }
+
+    public static void test_ignore_unsupported_options() throws Exception {
+        assertThrows(() -> { DriverManager.getConnection("jdbc:duckdb:;foo=bar;"); }, SQLException.class);
+        Properties config = new Properties();
+        config.put("boo", "bar");
+        config.put(JDBC_STREAM_RESULTS, true);
+        DriverManager.getConnection("jdbc:duckdb:;foo=bar;jdbc_ignore_unsupported_options=yes;", config).close();
     }
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
This is a backport of the PR #250 to `v1.3-ossivalis` stable branch.

Currently driver performs strict checks on the user-specified connection options. If stray options are passed - exception is thrown on connect.

This is considered to be a good feature, to prevent accidental typos in option names. But in some cases user does not have full control over the options passed to driver by other tools.

This change adds new boolean connection property
`jdbc_ignore_unsupported_options`, when it is enabled - all unsupported connection options are ignored.

When used with external tools, it is intended to be set in connection string like this:

```
jdbc:duckdb:;jdbc_ignore_unsupported_options=true;
```

Testing: new test added.

Fixes: #232