### PR TITLE
Support running an SQL file on init (1.3)

### DIFF
--- a/src/main/java/org/duckdb/JdbcUtils.java
+++ b/src/main/java/org/duckdb/JdbcUtils.java
@@ -19,7 +19,6 @@ final class JdbcUtils {
         return (T) obj;
     }
 
-
     static String removeOption(Properties props, String opt) {
         return removeOption(props, opt, null);
     }

--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -3638,7 +3638,7 @@ public class TestDuckDBJDBC {
         } else {
             statusCode = runTests(args, TestDuckDBJDBC.class, TestBatch.class, TestClosure.class,
                                   TestExtensionTypes.class, TestSpatial.class, TestParameterMetadata.class,
-                                  TestPrepare.class, TestResults.class, TestTimestamp.class);
+                                  TestPrepare.class, TestResults.class, TestSessionInit.class, TestTimestamp.class);
         }
         System.exit(statusCode);
     }

--- a/src/test/java/org/duckdb/TestSessionInit.java
+++ b/src/test/java/org/duckdb/TestSessionInit.java
@@ -1,0 +1,161 @@
+package org.duckdb;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.duckdb.JdbcUtils.bytesToHex;
+import static org.duckdb.test.Assertions.*;
+
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.DigestOutputStream;
+import java.security.MessageDigest;
+import java.sql.*;
+import java.util.Properties;
+import org.duckdb.test.TempDirectory;
+
+public class TestSessionInit {
+
+    public static void test_session_init_db_only() throws Exception {
+        try (TempDirectory td = new TempDirectory()) {
+            Path initSqlFile = td.path().resolve("init.sql");
+            Files.write(initSqlFile, "CREATE TABLE tab1(col1 int);".getBytes());
+            try (Connection conn = DriverManager.getConnection("jdbc:duckdb:;session_init_sql_file=" + initSqlFile);
+                 Statement stmt = conn.createStatement()) {
+                stmt.execute("DROP TABLE tab1");
+            }
+        }
+    }
+
+    public static void test_session_init_db_and_connection() throws Exception {
+        try (TempDirectory td = new TempDirectory()) {
+            Path initSqlFile = td.path().resolve("init.sql");
+            Files.write(initSqlFile, ("CREATE TABLE tab1(col1 int);\n"
+                                      + " /* DUCKDB_CONNECTION_INIT_BELOW_MARKER   */ \n"
+                                      + "INSERT INTO tab1 VALUES(42);")
+                                         .getBytes());
+            String url = "jdbc:duckdb:memory:test1;session_init_sql_file=" + initSqlFile;
+            try (Connection conn1 = DriverManager.getConnection(url);
+                 Connection conn2 = DriverManager.getConnection(url); Statement stmt = conn2.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT * FROM tab1")) {
+                rs.next();
+                assertEquals(rs.getInt(1), 42);
+                rs.next();
+                assertEquals(rs.getInt(1), 42);
+            }
+        }
+    }
+
+    public static void test_session_init_connection_only() throws Exception {
+        try (TempDirectory td = new TempDirectory()) {
+            Path initSqlFile = td.path().resolve("init.sql");
+            Files.write(initSqlFile, (" /* DUCKDB_CONNECTION_INIT_BELOW_MARKER   */ \n"
+                                      + "CREATE TABLE tab1(col1 int)")
+                                         .getBytes());
+            try (Connection conn = DriverManager.getConnection("jdbc:duckdb:;session_init_sql_file=" + initSqlFile);
+                 Statement stmt = conn.createStatement()) {
+                stmt.execute("DROP TABLE tab1");
+            }
+        }
+    }
+
+    public static void test_session_init_sha256() throws Exception {
+        try (TempDirectory td = new TempDirectory()) {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            Path initSqlFile = td.path().resolve("init.sql");
+
+            final DigestOutputStream dos;
+            try (OutputStream os = Files.newOutputStream(initSqlFile)) {
+                dos = new DigestOutputStream(os, md);
+                dos.write("CREATE TABLE tab1(col1 int)".getBytes(UTF_8));
+                dos.flush();
+            }
+
+            String sha256 = bytesToHex(md.digest());
+            try (Connection conn = DriverManager.getConnection("jdbc:duckdb:;"
+                                                               + "session_init_sql_file=" + initSqlFile + ";"
+                                                               + "session_init_sql_file_sha256=" + sha256);
+                 Statement stmt = conn.createStatement()) {
+                stmt.execute("DROP TABLE tab1");
+            }
+
+            assertThrows(() -> {
+                DriverManager.getConnection("jdbc:duckdb:;"
+                                            + "session_init_sql_file=" + initSqlFile + ";"
+                                            + "session_init_sql_file_sha25=fail");
+            }, SQLException.class);
+
+            assertThrows(() -> {
+                DriverManager.getConnection("jdbc:duckdb:"
+                                            + "session_init_sql_file=" + initSqlFile + ";"
+                                            + "threads=1;"
+                                            + "session_init_sql_file_sha256=" + sha256);
+            }, SQLException.class);
+
+            assertThrows(() -> {
+                DriverManager.getConnection("jdbc:duckdb:;"
+                                            + "session_init_sql_file=" + initSqlFile + ";"
+                                            + "session_init_sql_file_sha256=" + sha256 + ";"
+                                            + "session_init_sql_file_sha256=" + sha256);
+            }, SQLException.class);
+
+            assertThrows(() -> {
+                Properties config = new Properties();
+                config.put("session_init_sql_file_sha256", sha256);
+                DriverManager.getConnection("jdbc:duckdb:;"
+                                                + "session_init_sql_file=" + initSqlFile,
+                                            config);
+            }, SQLException.class);
+        }
+    }
+
+    public static void test_session_init_tracing() throws Exception {
+        String sql = " CREATE TABLE tab1(col1 int)\n\n";
+        try (TempDirectory td = new TempDirectory()) {
+            Path initSqlFile = td.path().resolve("init.sql");
+            Files.write(initSqlFile, sql.getBytes());
+            try (DuckDBConnection conn =
+                     DriverManager.getConnection("jdbc:duckdb:;session_init_sql_file=" + initSqlFile)
+                         .unwrap(DuckDBConnection.class)) {
+                assertEquals(conn.getSessionInitSQL(), sql);
+            }
+        }
+    }
+
+    public static void test_session_init_invalid_params() throws Exception {
+        try (TempDirectory td = new TempDirectory()) {
+            Path initSqlFile = td.path().resolve("init.sql");
+            Files.write(initSqlFile, "CREATE TABLE tab1(col1 int);".getBytes());
+            DriverManager.getConnection("jdbc:duckdb:;session_init_sql_file=" + initSqlFile).close();
+            assertThrows(() -> {
+                DriverManager.getConnection("jdbc:duckdb:;"
+                                            + "threads=1;"
+                                            + "session_init_sql_file=" + initSqlFile);
+            }, SQLException.class);
+            assertThrows(() -> {
+                DriverManager.getConnection("jdbc:duckdb:;"
+                                            + "session_init_sql_file=" + initSqlFile + ";"
+                                            + "session_init_sql_file=" + initSqlFile);
+            }, SQLException.class);
+            assertThrows(() -> {
+                Properties config = new Properties();
+                config.put("session_init_sql_file", "initSqlFile");
+                DriverManager.getConnection("jdbc:duckdb:;", config);
+            }, SQLException.class);
+        }
+    }
+
+    public static void test_session_init_invalid_file() throws Exception {
+        try (TempDirectory td = new TempDirectory()) {
+            Path initSqlFile = td.path().resolve("init.sql");
+            Files.write(initSqlFile, ("CREATE TABLE tab1(col1 int);\n"
+                                      + " /* DUCKDB_CONNECTION_INIT_BELOW_MARKER   */ \n"
+                                      + "INSERT INTO tab1 VALUES(42);\n"
+                                      + " /* DUCKDB_CONNECTION_INIT_BELOW_MARKER   */ \n"
+                                      + "INSERT INTO tab1 VALUES(43);\n")
+                                         .getBytes());
+            assertThrows(() -> {
+                DriverManager.getConnection("jdbc:duckdb:;session_init_sql_file=" + initSqlFile);
+            }, SQLException.class);
+        }
+    }
+}

--- a/src/test/java/org/duckdb/test/TempDirectory.java
+++ b/src/test/java/org/duckdb/test/TempDirectory.java
@@ -1,0 +1,32 @@
+package org.duckdb.test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+
+public class TempDirectory implements AutoCloseable {
+    private final Path tempDir;
+
+    public TempDirectory() throws IOException {
+        this.tempDir = Files.createTempDirectory("duckdb_tempdir_");
+    }
+
+    public Path path() {
+        return tempDir;
+    }
+
+    @Override
+    public void close() throws IOException {
+        // Recursively delete the directory and its contents
+        if (Files.exists(tempDir)) {
+            Files.walk(tempDir).sorted(Comparator.reverseOrder()).forEach(p -> {
+                try {
+                    Files.delete(p);
+                } catch (IOException e) {
+                    throw new RuntimeException("Failed to delete " + p, e);
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
This is a backport of the PR #252 to `v1.3-ossivalis` stable branch.

This change adds support for `session_init_sql_file` connection option, that allows to speficy the path to an SQL file in local file system, that will be read by the driver and executed in a newly created connection before passing it to user.

By default the file is initalized only once per database, on the first connection established to this DB.

For `:memory:` connection-private DBs it effectively executed once per connection.

In addition to the DB init, it supports executing a part of the SQL file for every connection. It looks for the specific marker:

```
/* DUCKDB_CONNECTION_INIT_BELOW_MARKER */
```

in the SQL file. If this marker is present - everything before the marker is executed on DB init, and everything after this marker - on connection init.

DB init is not re-run when the DB is closed and re-opened after the last connection to it was closed and then new one created. If such re-init is necessary - `jdbc_pin_db` option is supposed to be used instead.

It is understood, that this feature can be security sensitive (it effectively implements an RCE entry) in contexts, where other applications/processes/users can control the appending to user-specified connection string or re-writing the specified file in local file system. The following security measures are taken to mitigate that:

 - `session_init_sql_file` option can only be specified in the connection string itself, it is not accepted as part of connection `Properties`
 - `session_init_sql_file` option must be specified as the first option in the connection string, for example: 'jdbc:duckdb:;session_init_sql_file=/path/to/init.sql'
 - `session_init_sql_file_sha256=<sha56sum_of_sql_file>` option can be specified, the file contents SHA-256 sum is checked againts this value
 - `session_init_sql_file_sha256` option can only be specified in the connection string itself
 - `session_init_sql_file` and `session_init_sql_file_sha256` options cannot be specified multiple times
 - content of the SQL file are available to the running code using `DuckDBConnection#getSessionInitSQL()` method

Testing: new tests added in a separate file.