### PR TITLE
Enable rs streaming and DB pinning for DuckLake

### DIFF
--- a/src/main/java/org/duckdb/DuckDBDriver.java
+++ b/src/main/java/org/duckdb/DuckDBDriver.java
@@ -32,6 +32,7 @@ public class DuckDBDriver implements java.sql.Driver {
 
     static final String DUCKDB_URL_PREFIX = "jdbc:duckdb:";
     static final String MEMORY_DB = ":memory:";
+    private static final String DUCKLAKE_URL_PREFIX = DUCKDB_URL_PREFIX + "ducklake:";
 
     static final ScheduledThreadPoolExecutor scheduler;
 
@@ -101,6 +102,12 @@ public class DuckDBDriver implements java.sql.Driver {
         // passed by mistake, so we need to ignore it to allow the connection
         // to be established.
         props.remove("path");
+
+        // DuckLake connection
+        if (pp.shortUrl.startsWith(DUCKLAKE_URL_PREFIX)) {
+            setDefaultOptionValue(props, JDBC_PIN_DB, true);
+            setDefaultOptionValue(props, JDBC_STREAM_RESULTS, true);
+        }
 
         // Pin DB option
         String pinDbOptStr = removeOption(props, JDBC_PIN_DB);


### PR DESCRIPTION
This is a manual backport of the PR #258 to `v1.3-ossivalis` stable branch.

The support for direct attach, was recently added to DuckLake in duckdb/ducklake#201. JDBC connection string example:

```
jdbc:duckdb:ducklake:postgres:postgresql://user:pwd@127.0.0.1:5432/lake1
```

This change enables `jdbc_stream_results` and `jdbc_pin_db` options by default (unless they are specified by user) for DuckLake connections.

Testing: test coverage pending as DuckLake is not yet available in the `main` barnch.