### PR TITLE
DuckLake options override fix

### DIFF
--- a/src/main/java/org/duckdb/JdbcUtils.java
+++ b/src/main/java/org/duckdb/JdbcUtils.java
@@ -32,7 +32,7 @@ final class JdbcUtils {
     }
 
     static void setDefaultOptionValue(Properties props, String opt, Object value) {
-        if (props.contains(opt)) {
+        if (props.containsKey(opt)) {
             return;
         }
         props.put(opt, value);


### PR DESCRIPTION
With the changes introduced in #276 the `jdbc:duckdb:ducklake:...` URLs have the special handling: `jdbc_pin_db` and `jdbc_stream_results` options are applied to them automatically. This behaviour was supposed to be overridable with URL or `Properties` but by mistake incorrect method was used for override check. And as DuckLake is still not available in the `main` branch, there is no test coverage for this and the problem got into `1.3.1.0` update.

Fixes: #283