### PR TITLE
Add OSGi metadata to manifest file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(JAVA_JVM_LIBRARY NotNeeded)
 
 find_package(JNI)
 
-cmake_minimum_required(VERSION 3.11.0)
+cmake_minimum_required(VERSION 3.5...3.29)
 set(CMAKE_CXX_STANDARD "11" CACHE STRING "C++ standard to enforce")
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -556,6 +556,7 @@ file(GLOB_RECURSE JAVA_TEST_FILES src/test/java/org/duckdb/*.java)
 set(CMAKE_JAVA_COMPILE_FLAGS -encoding utf-8 -g)
 
 add_jar(duckdb_jdbc ${JAVA_SRC_FILES} META-INF/services/java.sql.Driver
+        MANIFEST META-INF/MANIFEST.MF
         GENERATE_NATIVE_HEADERS duckdb-native)
 add_jar(duckdb_jdbc_tests ${JAVA_TEST_FILES} INCLUDE_JARS duckdb_jdbc)
 

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -7,7 +7,7 @@ set(JAVA_JVM_LIBRARY NotNeeded)
 
 find_package(JNI)
 
-cmake_minimum_required(VERSION 3.11.0)
+cmake_minimum_required(VERSION 3.5...3.29)
 set(CMAKE_CXX_STANDARD "11" CACHE STRING "C++ standard to enforce")
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -86,6 +86,7 @@ file(GLOB_RECURSE JAVA_TEST_FILES src/test/java/org/duckdb/*.java)
 set(CMAKE_JAVA_COMPILE_FLAGS -encoding utf-8 -g)
 
 add_jar(duckdb_jdbc ${JAVA_SRC_FILES} META-INF/services/java.sql.Driver
+        MANIFEST META-INF/MANIFEST.MF
         GENERATE_NATIVE_HEADERS duckdb-native)
 add_jar(duckdb_jdbc_tests ${JAVA_TEST_FILES} INCLUDE_JARS duckdb_jdbc)
 

--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -1,0 +1,13 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: DuckDB JDBC Driver
+Bundle-SymbolicName: org.duckdb.duckdb_jdbc
+Bundle-Version: 1.4.0.0
+Bundle-Vendor: DuckDB Labs
+Bundle-Description: A JDBC-compliant driver for the DuckDB data management system
+Bundle-License: https://raw.githubusercontent.com/duckdb/duckdb/main/LICENSE
+Bundle-DocURL: https://www.duckdb.org
+Bundle-ContactAddress: mark@duckdblabs.com
+Bundle-Copyright: Copyright (c) DuckDB Labs
+Export-Package: org.duckdb, org.duckdb.io, org.duckdb.user
+Import-Package: javax.sql, org.osgi.framework;resolution:=optional


### PR DESCRIPTION
This change adds the static manifest file to be included into the JAR during the build.

Fixes: #285