### PR TITLE
Add UUID support to `DuckDBAppender` (fixes #313)

### DIFF
--- a/src/main/java/org/duckdb/DuckDBBindings.java
+++ b/src/main/java/org/duckdb/DuckDBBindings.java
@@ -171,7 +171,7 @@ public class DuckDBBindings {
         // duckdb_array, only useful as logical type
         DUCKDB_TYPE_ARRAY(33, 0),
         // duckdb_hugeint
-        DUCKDB_TYPE_UUID(27),
+        DUCKDB_TYPE_UUID(27, 16),
         // union type, only useful as logical type
         DUCKDB_TYPE_UNION(28),
         // duckdb_bit

--- a/src/test/java/org/duckdb/TestAppender.java
+++ b/src/test/java/org/duckdb/TestAppender.java
@@ -152,7 +152,8 @@ public class TestAppender {
                 appender.flush();
             }
 
-            try (DuckDBResultSet rs = stmt.executeQuery("SELECT * FROM tab1 ORDER BY col1").unwrap(DuckDBResultSet.class)) {
+            try (DuckDBResultSet rs =
+                     stmt.executeQuery("SELECT * FROM tab1 ORDER BY col1").unwrap(DuckDBResultSet.class)) {
                 assertTrue(rs.next());
                 assertEquals(rs.getUuid(2), uuid1);
                 assertEquals(rs.getObject(2, UUID.class), uuid1);


### PR DESCRIPTION
Previously, attempting to append a UUID would result in an `unsupported C API type: 27` error which is documented in https://github.com/duckdb/duckdb-java/issues/313. This change enables the `DuckDBAppender` to handle `java.util.UUID` objects directly.