### PR TITLE
Revert GCC 12 downgrade for Linux builds

### DIFF
--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -49,9 +49,7 @@ jobs:
             cat /etc/os-release
             dnf install -y \
               java-1.8.0-openjdk-devel \
-              ninja-build \
-              gcc-toolset-12-gcc-c++
-            source /opt/rh/gcc-toolset-12/enable
+              ninja-build
             make -C /duckdb release
           "
 
@@ -154,9 +152,7 @@ jobs:
             cat /etc/os-release
             dnf install -y \
               java-1.8.0-openjdk-devel \
-              ninja-build \
-              gcc-toolset-12-gcc-c++
-            source /opt/rh/gcc-toolset-12/enable
+              ninja-build
             make -C /duckdb release
           "
 


### PR DESCRIPTION
This change revert the usage of `gcc-toolset-12` for `x86_64` and `aarch64` Linux builds. See duckdb/duckdb#17963 for details.