### PR TITLE
Update vendored DuckDB sources to c5310ec83b

### DIFF
--- a/src/duckdb/src/function/table/version/pragma_version.cpp
+++ b/src/duckdb/src/function/table/version/pragma_version.cpp
@@ -1,5 +1,5 @@
 #ifndef DUCKDB_PATCH_VERSION
-#define DUCKDB_PATCH_VERSION "3-dev190"
+#define DUCKDB_PATCH_VERSION "3-dev200"
 #endif
 #ifndef DUCKDB_MINOR_VERSION
 #define DUCKDB_MINOR_VERSION 3
@@ -8,10 +8,10 @@
 #define DUCKDB_MAJOR_VERSION 1
 #endif
 #ifndef DUCKDB_VERSION
-#define DUCKDB_VERSION "v1.3.3-dev190"
+#define DUCKDB_VERSION "v1.3.3-dev200"
 #endif
 #ifndef DUCKDB_SOURCE_ID
-#define DUCKDB_SOURCE_ID "aaa4635fff"
+#define DUCKDB_SOURCE_ID "c5310ec83b"
 #endif
 #include "duckdb/function/table/system_functions.hpp"
 #include "duckdb/main/database.hpp"


### PR DESCRIPTION
Changes:
 - [duckdb/duckdb#c5310ec83b](https://github.com/duckdb/duckdb/commit/c5310ec83b) imported at 2025-08-22 06:58:39
