### PR TITLE
Fix timestamp before epoch with micros/nanos (1.4)

### DIFF
--- a/src/main/java/org/duckdb/DuckDBTimestamp.java
+++ b/src/main/java/org/duckdb/DuckDBTimestamp.java
@@ -40,13 +40,13 @@ public class DuckDBTimestamp {
         case MILLIS:
             return Instant.ofEpochMilli(value);
         case MICROS: {
-            long epochSecond = value / 1_000_000;
-            int nanoAdjustment = nanosPartMicros(value);
+            long epochSecond = value / 1_000_000L;
+            long nanoAdjustment = (value % 1_000_000L) * 1000L;
             return Instant.ofEpochSecond(epochSecond, nanoAdjustment);
         }
         case NANOS: {
-            long epochSecond = value / 1_000_000_000;
-            long nanoAdjustment = nanosPartNanos(value);
+            long epochSecond = value / 1_000_000_000L;
+            long nanoAdjustment = value % 1_000_000_000L;
             return Instant.ofEpochSecond(epochSecond, nanoAdjustment);
         }
         default:
@@ -164,22 +164,6 @@ public class DuckDBTimestamp {
             return (int) ((micros % 1000_000L) * 1000);
         } else {
             return (int) ((1000_000L + (micros % 1000_000L)) * 1000);
-        }
-    }
-
-    private static long nanos2seconds(long nanos) {
-        if ((nanos % 1_000_000_000L) >= 0) {
-            return nanos / 1_000_000_000L;
-        } else {
-            return (nanos / 1_000_000_000L) - 1;
-        }
-    }
-
-    private static int nanosPartNanos(long nanos) {
-        if ((nanos % 1_000_000_000L) >= 0) {
-            return (int) ((nanos % 1_000_000_000L));
-        } else {
-            return (int) ((1_000_000_000L + (nanos % 1_000_000_000L)));
         }
     }
 }

--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -2283,7 +2283,7 @@ public class TestDuckDBJDBC {
                                     localDateTimeToOffset(LocalDateTime.ofInstant(
                                         Instant.parse("+294247-01-10T04:00:54.775807Z"), ZoneId.systemDefault())),
                                     localDateTimeToOffset(LocalDateTime.ofInstant(
-                                        Instant.parse("-290308-12-21T19:59:06.224193Z"), ZoneId.systemDefault())),
+                                        Instant.parse("-290308-12-21T19:59:05.224193Z"), ZoneId.systemDefault())),
                                     null,
                                     localDateTimeToOffset(LocalDateTime.ofInstant(Instant.parse("2022-05-12T23:23:45Z"),
                                                                                   ZoneId.systemDefault()))));


### PR DESCRIPTION
This is a backport of the PR #377 to `v1.4-andium` stable branch.

This PR fixes the problem with converting `TIMESTAMP` values into `LocalDateTime` where, when micros/nanos part was present, the calculation may have been shifted by 1 second.

Fixes: #336