### PR TITLE
Appender: support nested STRUCTs (1.4)

### DIFF
--- a/src/test/java/org/duckdb/TestAppender.java
+++ b/src/test/java/org/duckdb/TestAppender.java
@@ -776,7 +776,7 @@ public class TestAppender {
 
             assertThrows(() -> {
                 try (DuckDBAppender appender = conn.createAppender("decimals")) {
-                    appender.append(1).beginRow().append(new BigDecimal("121.14").setScale(2));
+                    appender.beginRow().append(1).append(new BigDecimal("121.14").setScale(2));
                 }
             }, SQLException.class);
 
@@ -1656,6 +1656,45 @@ public class TestAppender {
         }
     }
 
+    public static void test_appender_struct_nested() throws Exception {
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+            stmt.execute(
+                "CREATE TABLE tab1 (col1 INTEGER, col2 STRUCT(s1 INTEGER, s2 STRUCT(ns1 INTEGER, ns2 VARCHAR)), col3 VARCHAR)");
+
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                appender.beginRow()
+                    .append(42)
+                    .beginStruct()
+                    .append(43)
+                    .beginStruct()
+                    .append(44)
+                    .append("foo")
+                    .endStruct()
+                    .endStruct()
+                    .append("bar")
+                    .endRow()
+                    .flush();
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT * FROM tab1 WHERE col1 = 42")) {
+                assertTrue(rs.next());
+
+                assertEquals(rs.getInt(1), 42);
+                DuckDBStruct struct = (DuckDBStruct) rs.getObject(2);
+                Map<String, Object> map = struct.getMap();
+                assertEquals(map.get("s1"), 43);
+                DuckDBStruct nested = (DuckDBStruct) map.get("s2");
+                Map<String, Object> nestedMap = nested.getMap();
+                assertEquals(nestedMap.get("ns1"), 44);
+                assertEquals(nestedMap.get("ns2"), "foo");
+                assertEquals(rs.getString(3), "bar");
+
+                assertFalse(rs.next());
+            }
+        }
+    }
+
     public static void test_appender_struct_with_array() throws Exception {
         try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
              Statement stmt = conn.createStatement()) {
@@ -1916,6 +1955,87 @@ public class TestAppender {
                         assertEquals(obj, "foo" + i);
                     }
                 }
+
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    public static void test_appender_union_nested() throws Exception {
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE tab1 ("
+                         + "col1 INTEGER, "
+                         + "col2 STRUCT( "
+                         + "   s1 INTEGER, "
+                         + "   s2 UNION("
+                         + "       u1 INTEGER,"
+                         + "       u2 STRUCT("
+                         + "           us1 INTEGER, "
+                         + "           us2 INTEGER[2],"
+                         + "           us3 VARCHAR"
+                         + "       )"
+                         + "   )"
+                         + "), "
+                         + "col3 VARCHAR)");
+
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                appender.beginRow()
+                    .append(42)
+                    .beginStruct()
+                    .append(43)
+                    .beginUnion("u1")
+                    .append(44)
+                    .endUnion()
+                    .endStruct()
+                    .append("foo")
+                    .endRow()
+
+                    .beginRow()
+                    .append(45)
+                    .beginStruct()
+                    .append(46)
+                    .beginUnion("u2")
+                    .beginStruct()
+                    .append(47)
+                    .append(new int[] {48, 49})
+                    .append("bar")
+                    .endStruct()
+                    .endUnion()
+                    .endStruct()
+                    .append("baz")
+                    .endRow();
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT * FROM tab1 ORDER BY col1")) {
+                assertTrue(rs.next());
+
+                assertEquals(rs.getInt(1), 42);
+                DuckDBStruct struct = (DuckDBStruct) rs.getObject(2);
+                Map<String, Object> map = struct.getMap();
+                assertEquals(map.size(), 2);
+                assertEquals(map.get("s1"), 43);
+                assertEquals(map.get("s2"), 44);
+                assertEquals(rs.getString(3), "foo");
+
+                assertTrue(rs.next());
+
+                assertEquals(rs.getInt(1), 45);
+                DuckDBStruct struct1 = (DuckDBStruct) rs.getObject(2);
+                Map<String, Object> map1 = struct1.getMap();
+                assertEquals(map1.size(), 2);
+                assertEquals(map1.get("s1"), 46);
+                DuckDBStruct struct2 = (DuckDBStruct) map1.get("s2");
+                Map<String, Object> map2 = struct2.getMap();
+                assertEquals(map2.size(), 3);
+                assertEquals(map2.get("us1"), 47);
+                DuckDBArray arrWrapper = (DuckDBArray) map2.get("us2");
+                Object[] arr = (Object[]) arrWrapper.getArray();
+                assertEquals(arr.length, 2);
+                assertEquals(arr[0], 48);
+                assertEquals(arr[1], 49);
+                assertEquals(map2.get("us3"), "bar");
+                assertEquals(rs.getString(3), "baz");
 
                 assertFalse(rs.next());
             }


### PR DESCRIPTION
This is a backport of the PR #396 to `v1.4-andium` stable branch.

This PR adds support to nested `STRUCT` and `UNION` columns in `Appender`. There are no nesting limit enforced on Java side.

Testing: existing test is extended to cover nested `STRUCT`s.