### PR TITLE
Appender: support nested lists and maps (1.4)

### DIFF
--- a/src/main/java/org/duckdb/DuckDBBindings.java
+++ b/src/main/java/org/duckdb/DuckDBBindings.java
@@ -169,7 +169,7 @@ public class DuckDBBindings {
         // struct type, only useful as logical type
         DUCKDB_TYPE_STRUCT(25, 0),
         // map type, only useful as logical type
-        DUCKDB_TYPE_MAP(26),
+        DUCKDB_TYPE_MAP(26, 16),
         // duckdb_array, only useful as logical type
         DUCKDB_TYPE_ARRAY(33, 0),
         // duckdb_hugeint

--- a/src/main/java/org/duckdb/DuckDBResultSetMetaData.java
+++ b/src/main/java/org/duckdb/DuckDBResultSetMetaData.java
@@ -12,7 +12,7 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.UUID;
 
 public class DuckDBResultSetMetaData implements ResultSetMetaData {
@@ -234,7 +234,7 @@ public class DuckDBResultSetMetaData implements ResultSetMetaData {
         case ARRAY:
             return DuckDBArray.class.getName();
         case MAP:
-            return HashMap.class.getName();
+            return LinkedHashMap.class.getName();
         case STRUCT:
             return DuckDBStruct.class.getName();
         default:

--- a/src/main/java/org/duckdb/DuckDBVector.java
+++ b/src/main/java/org/duckdb/DuckDBVector.java
@@ -286,7 +286,7 @@ class DuckDBVector {
         }
 
         Object[] entries = (Object[]) (((Array) varlen_data[idx]).getArray());
-        Map<Object, Object> result = new HashMap<>();
+        Map<Object, Object> result = new LinkedHashMap<>();
 
         for (Object entry : entries) {
             Object[] entry_val = ((Struct) entry).getAttributes();

--- a/src/test/java/org/duckdb/TestAppender.java
+++ b/src/test/java/org/duckdb/TestAppender.java
@@ -144,8 +144,8 @@ public class TestAppender {
              Statement stmt = conn.createStatement()) {
 
             stmt.execute("CREATE TABLE tab1(col1 INT, col2 UUID)");
-            UUID uuid1 = UUID.randomUUID();
-            UUID uuid2 = UUID.randomUUID();
+            UUID uuid1 = UUID.fromString("777dfbdb-83e7-40f5-ae1b-e12215bdd798");
+            UUID uuid2 = UUID.fromString("b8708825-3b58-45a1-9a6e-dab053c3f387");
             try (DuckDBAppender appender = conn.createAppender("tab1")) {
                 appender.beginRow().append(1).append(uuid1).endRow();
                 appender.beginRow().append(2).append(uuid2).endRow();

--- a/src/test/java/org/duckdb/TestAppenderCollection.java
+++ b/src/test/java/org/duckdb/TestAppenderCollection.java
@@ -1,12 +1,15 @@
 package org.duckdb;
 
+import static java.util.Arrays.asList;
 import static org.duckdb.TestDuckDBJDBC.JDBC_URL;
 import static org.duckdb.test.Assertions.*;
 import static org.duckdb.test.Assertions.assertFalse;
+import static org.duckdb.test.Helpers.createMap;
 
-import java.sql.DriverManager;
-import java.sql.ResultSet;
-import java.sql.Statement;
+import java.sql.*;
+import java.time.*;
+import java.util.*;
+import java.util.Date;
 
 public class TestAppenderCollection {
     public static void test_appender_array_basic() throws Exception {
@@ -99,54 +102,6 @@ public class TestAppenderCollection {
         }
     }
 
-    public static void test_appender_nested_array_bool() throws Exception {
-        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
-             Statement stmt = conn.createStatement()) {
-
-            int count = 1 << 11;         // auto flush
-            int tail = 17;               // flushed on close
-            int arrayLen = (1 << 6) + 5; // increase this for stress tests
-            int childLen = (1 << 6) + 7;
-
-            stmt.execute("CREATE TABLE tab1(col1 INT, col2 BOOLEAN[" + childLen + "][" + arrayLen + "])");
-
-            try (DuckDBAppender appender = conn.createAppender("tab1")) {
-                for (int i = 0; i < count + tail; i++) {
-                    boolean[][] arr = new boolean[arrayLen][childLen];
-                    for (int j = 0; j < arrayLen; j++) {
-                        for (int k = 0; k < childLen; k++) {
-                            arr[j][k] = 0 == (i + j + k) % 2;
-                        }
-                    }
-                    appender.beginRow().append(i).append(arr).endRow();
-                }
-            }
-
-            try (ResultSet rs = stmt.executeQuery("SELECT col1, col2[" + (arrayLen - 1) + "][" + (childLen - 1) +
-                                                  "] FROM tab1 ORDER BY col1")) {
-                for (int i = 0; i < count + tail; i++) {
-                    assertTrue(rs.next());
-                    assertEquals(rs.getInt(1), i);
-                    assertEquals(rs.getBoolean(2), 0 == (i + arrayLen + childLen - 4) % 2);
-                }
-                assertFalse(rs.next());
-            }
-
-            int row = count - 2;
-            try (Statement stmt2 = conn.createStatement();
-                 ResultSet rs2 = stmt2.executeQuery(
-                     "SELECT unnest(ucol2) FROM (SELECT unnest(col2) as ucol2 FROM tab1 WHERE col1 = " + row + ")")) {
-                for (int j = 0; j < arrayLen; j++) {
-                    for (int k = 0; k < childLen; k++) {
-                        assertTrue(rs2.next());
-                        assertEquals(rs2.getBoolean(1), 0 == (row + j + k) % 2);
-                    }
-                }
-                assertFalse(rs2.next());
-            }
-        }
-    }
-
     public static void test_appender_array_tinyint() throws Exception {
         int count = 1 << 11;         // auto flush
         int tail = 16;               // flushed on close
@@ -188,54 +143,6 @@ public class TestAppenderCollection {
                     }
                     assertFalse(rs2.next());
                 }
-            }
-        }
-    }
-
-    public static void test_appender_nested_array_tinyint() throws Exception {
-        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
-             Statement stmt = conn.createStatement()) {
-
-            int count = 1 << 11;         // auto flush
-            int tail = 17;               // flushed on close
-            int arrayLen = (1 << 6) + 5; // increase this for stress tests
-            int childLen = (1 << 6) + 7;
-
-            stmt.execute("CREATE TABLE tab1(col1 INT, col2 TINYINT[" + childLen + "][" + arrayLen + "])");
-
-            try (DuckDBAppender appender = conn.createAppender("tab1")) {
-                for (int i = 0; i < count + tail; i++) {
-                    byte[][] arr = new byte[arrayLen][childLen];
-                    for (int j = 0; j < arrayLen; j++) {
-                        for (int k = 0; k < childLen; k++) {
-                            arr[j][k] = (byte) (i + j + k);
-                        }
-                    }
-                    appender.beginRow().append(i).appendByteArray(arr).endRow();
-                }
-            }
-
-            try (ResultSet rs = stmt.executeQuery("SELECT col1, col2[" + (arrayLen - 1) + "][" + (childLen - 1) +
-                                                  "] FROM tab1 ORDER BY col1")) {
-                for (int i = 0; i < count + tail; i++) {
-                    assertTrue(rs.next());
-                    assertEquals(rs.getInt(1), i);
-                    assertEquals(rs.getByte(2), (byte) (i + arrayLen + childLen - 4));
-                }
-                assertFalse(rs.next());
-            }
-
-            int row = count - 2;
-            try (Statement stmt2 = conn.createStatement();
-                 ResultSet rs2 = stmt2.executeQuery(
-                     "SELECT unnest(ucol2) FROM (SELECT unnest(col2) as ucol2 FROM tab1 WHERE col1 = " + row + ")")) {
-                for (int j = 0; j < arrayLen; j++) {
-                    for (int k = 0; k < childLen; k++) {
-                        assertTrue(rs2.next());
-                        assertEquals(rs2.getByte(1), (byte) (row + j + k));
-                    }
-                }
-                assertFalse(rs2.next());
             }
         }
     }
@@ -285,54 +192,6 @@ public class TestAppenderCollection {
         }
     }
 
-    public static void test_appender_nested_array_smallint() throws Exception {
-        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
-             Statement stmt = conn.createStatement()) {
-
-            int count = 1 << 11;         // auto flush
-            int tail = 17;               // flushed on close
-            int arrayLen = (1 << 6) + 5; // increase this for stress tests
-            int childLen = (1 << 6) + 7;
-
-            stmt.execute("CREATE TABLE tab1(col1 INT, col2 SMALLINT[" + childLen + "][" + arrayLen + "])");
-
-            try (DuckDBAppender appender = conn.createAppender("tab1")) {
-                for (int i = 0; i < count + tail; i++) {
-                    short[][] arr = new short[arrayLen][childLen];
-                    for (int j = 0; j < arrayLen; j++) {
-                        for (int k = 0; k < childLen; k++) {
-                            arr[j][k] = (short) (i + j + k);
-                        }
-                    }
-                    appender.beginRow().append(i).append(arr).endRow();
-                }
-            }
-
-            try (ResultSet rs = stmt.executeQuery("SELECT col1, col2[" + (arrayLen - 1) + "][" + (childLen - 1) +
-                                                  "] FROM tab1 ORDER BY col1")) {
-                for (int i = 0; i < count + tail; i++) {
-                    assertTrue(rs.next());
-                    assertEquals(rs.getInt(1), i);
-                    assertEquals(rs.getShort(2), (short) (i + arrayLen + childLen - 4));
-                }
-                assertFalse(rs.next());
-            }
-
-            int row = count - 2;
-            try (Statement stmt2 = conn.createStatement();
-                 ResultSet rs2 = stmt2.executeQuery(
-                     "SELECT unnest(ucol2) FROM (SELECT unnest(col2) as ucol2 FROM tab1 WHERE col1 = " + row + ")")) {
-                for (int j = 0; j < arrayLen; j++) {
-                    for (int k = 0; k < childLen; k++) {
-                        assertTrue(rs2.next());
-                        assertEquals(rs2.getShort(1), (short) (row + j + k));
-                    }
-                }
-                assertFalse(rs2.next());
-            }
-        }
-    }
-
     public static void test_appender_array_integer() throws Exception {
         int count = 1 << 11;          // auto flush
         int tail = 16;                // flushed on close
@@ -374,144 +233,6 @@ public class TestAppenderCollection {
                     }
                     assertFalse(rs2.next());
                 }
-            }
-        }
-    }
-
-    public static void test_appender_nested_array_basic_integer() throws Exception {
-        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
-             Statement stmt = conn.createStatement()) {
-
-            stmt.execute("CREATE TABLE tab1(col1 INT, col2 INTEGER[2][3])");
-
-            try (DuckDBAppender appender = conn.createAppender("tab1")) {
-                appender.beginRow().append(41).append(new int[][] {{42, 43}, {44, 45}, {46, 47}}).endRow();
-                appender.beginRow().append(48).append(new int[][] {{49, 50}, null, {53, 54}}).endRow();
-                appender.beginRow()
-                    .append(55)
-                    .append(new int[][] {{56, 57}, {58, 59}, {60, 61}},
-                            new boolean[][] {{false, true}, {false, false}, {true, false}})
-                    .endRow();
-            }
-
-            try (ResultSet rs = stmt.executeQuery("SELECT col1, unnest(col2) FROM tab1 WHERE col1 = 41")) {
-                assertTrue(rs.next());
-                assertEquals(rs.getInt(1), 41);
-                Object[] array1 = (Object[]) rs.getArray(2).getArray();
-                assertEquals(array1.length, 2);
-                assertEquals(array1[0], 42);
-                assertEquals(array1[1], 43);
-
-                assertTrue(rs.next());
-                assertEquals(rs.getInt(1), 41);
-                Object[] array2 = (Object[]) rs.getArray(2).getArray();
-                assertEquals(array2.length, 2);
-                assertEquals(array2[0], 44);
-                assertEquals(array2[1], 45);
-
-                assertTrue(rs.next());
-                assertEquals(rs.getInt(1), 41);
-                Object[] array3 = (Object[]) rs.getArray(2).getArray();
-                assertEquals(array3.length, 2);
-                assertEquals(array3[0], 46);
-                assertEquals(array3[1], 47);
-
-                assertFalse(rs.next());
-            }
-
-            try (ResultSet rs = stmt.executeQuery("SELECT col1, unnest(col2) FROM tab1 WHERE col1 = 48")) {
-                assertTrue(rs.next());
-                assertEquals(rs.getInt(1), 48);
-                Object[] array1 = (Object[]) rs.getArray(2).getArray();
-                assertEquals(array1.length, 2);
-                assertEquals(array1[0], 49);
-                assertEquals(array1[1], 50);
-
-                assertTrue(rs.next());
-                assertEquals(rs.getInt(1), 48);
-                assertNull(rs.getObject(2));
-
-                assertTrue(rs.next());
-                assertEquals(rs.getInt(1), 48);
-                Object[] array3 = (Object[]) rs.getArray(2).getArray();
-                assertEquals(array3.length, 2);
-                assertEquals(array3[0], 53);
-                assertEquals(array3[1], 54);
-
-                assertFalse(rs.next());
-            }
-
-            try (ResultSet rs = stmt.executeQuery("SELECT col1, unnest(col2) FROM tab1 WHERE col1 = 55")) {
-                assertTrue(rs.next());
-                assertEquals(rs.getInt(1), 55);
-                Object[] array1 = (Object[]) rs.getArray(2).getArray();
-                assertEquals(array1.length, 2);
-                assertEquals(array1[0], 56);
-                assertNull(array1[1]);
-
-                assertTrue(rs.next());
-                assertEquals(rs.getInt(1), 55);
-                Object[] array2 = (Object[]) rs.getArray(2).getArray();
-                assertEquals(array2.length, 2);
-                assertEquals(array2[0], 58);
-                assertEquals(array2[1], 59);
-
-                assertTrue(rs.next());
-                assertEquals(rs.getInt(1), 55);
-                Object[] array3 = (Object[]) rs.getArray(2).getArray();
-                assertEquals(array3.length, 2);
-                assertNull(array3[0]);
-                assertEquals(array3[1], 61);
-
-                assertFalse(rs.next());
-            }
-        }
-    }
-
-    public static void test_appender_nested_array_integer() throws Exception {
-        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
-             Statement stmt = conn.createStatement()) {
-
-            int count = 1 << 12;         // auto flush twice
-            int tail = 17;               // flushed on close
-            int arrayLen = (1 << 6) + 5; // increase this for stress tests
-            int childLen = (1 << 6) + 7;
-
-            stmt.execute("CREATE TABLE tab1(col1 INT, col2 INTEGER[" + childLen + "][" + arrayLen + "])");
-
-            try (DuckDBAppender appender = conn.createAppender("tab1")) {
-                for (int i = 0; i < count + tail; i++) {
-                    int[][] arr = new int[arrayLen][childLen];
-                    for (int j = 0; j < arrayLen; j++) {
-                        for (int k = 0; k < childLen; k++) {
-                            arr[j][k] = (i + 1) * (j + 1) * (k + 1);
-                        }
-                    }
-                    appender.beginRow().append(i).append(arr).endRow();
-                }
-            }
-
-            try (ResultSet rs = stmt.executeQuery("SELECT col1, col2[" + (arrayLen - 1) + "][" + (childLen - 1) +
-                                                  "] FROM tab1 ORDER BY col1")) {
-                for (int i = 0; i < count + tail; i++) {
-                    assertTrue(rs.next());
-                    assertEquals(rs.getInt(1), i);
-                    assertEquals(rs.getInt(2), (i + 1) * (arrayLen - 1) * (childLen - 1));
-                }
-                assertFalse(rs.next());
-            }
-
-            int row = count - 2;
-            try (Statement stmt2 = conn.createStatement();
-                 ResultSet rs2 = stmt2.executeQuery(
-                     "SELECT unnest(ucol2) FROM (SELECT unnest(col2) as ucol2 FROM tab1 WHERE col1 = " + row + ")")) {
-                for (int j = 0; j < arrayLen; j++) {
-                    for (int k = 0; k < childLen; k++) {
-                        assertTrue(rs2.next());
-                        assertEquals(rs2.getInt(1), (row + 1) * (j + 1) * (k + 1));
-                    }
-                }
-                assertFalse(rs2.next());
             }
         }
     }
@@ -561,54 +282,6 @@ public class TestAppenderCollection {
         }
     }
 
-    public static void test_appender_nested_array_bigint() throws Exception {
-        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
-             Statement stmt = conn.createStatement()) {
-
-            int count = 1 << 11;         // auto flush
-            int tail = 17;               // flushed on close
-            int arrayLen = (1 << 6) + 5; // increase this for stress tests
-            int childLen = (1 << 6) + 7;
-
-            stmt.execute("CREATE TABLE tab1(col1 INT, col2 BIGINT[" + childLen + "][" + arrayLen + "])");
-
-            try (DuckDBAppender appender = conn.createAppender("tab1")) {
-                for (int i = 0; i < count + tail; i++) {
-                    long[][] arr = new long[arrayLen][childLen];
-                    for (int j = 0; j < arrayLen; j++) {
-                        for (int k = 0; k < childLen; k++) {
-                            arr[j][k] = (long) (i + 1) * (j + 1) * (k + 1);
-                        }
-                    }
-                    appender.beginRow().append(i).append(arr).endRow();
-                }
-            }
-
-            try (ResultSet rs = stmt.executeQuery("SELECT col1, col2[" + (arrayLen - 1) + "][" + (childLen - 1) +
-                                                  "] FROM tab1 ORDER BY col1")) {
-                for (int i = 0; i < count + tail; i++) {
-                    assertTrue(rs.next());
-                    assertEquals(rs.getInt(1), i);
-                    assertEquals(rs.getLong(2), (long) ((i + 1) * (arrayLen - 1) * (childLen - 1)));
-                }
-                assertFalse(rs.next());
-            }
-
-            int row = count - 2;
-            try (Statement stmt2 = conn.createStatement();
-                 ResultSet rs2 = stmt2.executeQuery(
-                     "SELECT unnest(ucol2) FROM (SELECT unnest(col2) as ucol2 FROM tab1 WHERE col1 = " + row + ")")) {
-                for (int j = 0; j < arrayLen; j++) {
-                    for (int k = 0; k < childLen; k++) {
-                        assertTrue(rs2.next());
-                        assertEquals(rs2.getLong(1), (long) (row + 1) * (j + 1) * (k + 1));
-                    }
-                }
-                assertFalse(rs2.next());
-            }
-        }
-    }
-
     public static void test_appender_array_float() throws Exception {
         int count = 1 << 11;          // auto flush
         int tail = 16;                // flushed on close
@@ -654,54 +327,6 @@ public class TestAppenderCollection {
         }
     }
 
-    public static void test_appender_nested_array_float() throws Exception {
-        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
-             Statement stmt = conn.createStatement()) {
-
-            int count = 1 << 12;         // auto flush twice
-            int tail = 17;               // flushed on close
-            int arrayLen = (1 << 6) + 5; // increase this for stress tests
-            int childLen = (1 << 6) + 7;
-
-            stmt.execute("CREATE TABLE tab1(col1 INT, col2 FLOAT[" + childLen + "][" + arrayLen + "])");
-
-            try (DuckDBAppender appender = conn.createAppender("tab1")) {
-                for (int i = 0; i < count + tail; i++) {
-                    float[][] arr = new float[arrayLen][childLen];
-                    for (int j = 0; j < arrayLen; j++) {
-                        for (int k = 0; k < childLen; k++) {
-                            arr[j][k] = (i + 1) * (j + 1) * (k + 1) + 0.001f;
-                        }
-                    }
-                    appender.beginRow().append(i).append(arr).endRow();
-                }
-            }
-
-            try (ResultSet rs = stmt.executeQuery("SELECT col1, col2[" + (arrayLen - 1) + "][" + (childLen - 1) +
-                                                  "] FROM tab1 ORDER BY col1")) {
-                for (int i = 0; i < count + tail; i++) {
-                    assertTrue(rs.next());
-                    assertEquals(rs.getInt(1), i);
-                    assertEquals(rs.getFloat(2), (i + 1) * (arrayLen - 1) * (childLen - 1) + 0.001f);
-                }
-                assertFalse(rs.next());
-            }
-
-            int row = count - 2;
-            try (Statement stmt2 = conn.createStatement();
-                 ResultSet rs2 = stmt2.executeQuery(
-                     "SELECT unnest(ucol2) FROM (SELECT unnest(col2) as ucol2 FROM tab1 WHERE col1 = " + row + ")")) {
-                for (int j = 0; j < arrayLen; j++) {
-                    for (int k = 0; k < childLen; k++) {
-                        assertTrue(rs2.next());
-                        assertEquals(rs2.getFloat(1), (row + 1) * (j + 1) * (k + 1) + 0.001f);
-                    }
-                }
-                assertFalse(rs2.next());
-            }
-        }
-    }
-
     public static void test_appender_array_double() throws Exception {
         int count = 1 << 11;          // auto flush
         int tail = 16;                // flushed on close
@@ -743,54 +368,6 @@ public class TestAppenderCollection {
                     }
                     assertFalse(rs2.next());
                 }
-            }
-        }
-    }
-
-    public static void test_appender_nested_array_double() throws Exception {
-        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
-             Statement stmt = conn.createStatement()) {
-
-            int count = 1 << 11;         // auto flush
-            int tail = 17;               // flushed on close
-            int arrayLen = (1 << 6) + 5; // increase this for stress tests
-            int childLen = (1 << 6) + 7;
-
-            stmt.execute("CREATE TABLE tab1(col1 INT, col2 DOUBLE[" + childLen + "][" + arrayLen + "])");
-
-            try (DuckDBAppender appender = conn.createAppender("tab1")) {
-                for (int i = 0; i < count + tail; i++) {
-                    double[][] arr = new double[arrayLen][childLen];
-                    for (int j = 0; j < arrayLen; j++) {
-                        for (int k = 0; k < childLen; k++) {
-                            arr[j][k] = (i + 1) * (j + 1) * (k + 1) + 0.001;
-                        }
-                    }
-                    appender.beginRow().append(i).append(arr).endRow();
-                }
-            }
-
-            try (ResultSet rs = stmt.executeQuery("SELECT col1, col2[" + (arrayLen - 1) + "][" + (childLen - 1) +
-                                                  "] FROM tab1 ORDER BY col1")) {
-                for (int i = 0; i < count + tail; i++) {
-                    assertTrue(rs.next());
-                    assertEquals(rs.getInt(1), i);
-                    assertEquals(rs.getDouble(2), (i + 1) * (arrayLen - 1) * (childLen - 1) + 0.001);
-                }
-                assertFalse(rs.next());
-            }
-
-            int row = count - 2;
-            try (Statement stmt2 = conn.createStatement();
-                 ResultSet rs2 = stmt2.executeQuery(
-                     "SELECT unnest(ucol2) FROM (SELECT unnest(col2) as ucol2 FROM tab1 WHERE col1 = " + row + ")")) {
-                for (int j = 0; j < arrayLen; j++) {
-                    for (int k = 0; k < childLen; k++) {
-                        assertTrue(rs2.next());
-                        assertEquals(rs2.getDouble(1), (row + 1) * (j + 1) * (k + 1) + 0.001);
-                    }
-                }
-                assertFalse(rs2.next());
             }
         }
     }
@@ -849,6 +426,1076 @@ public class TestAppenderCollection {
                 assertTrue(rs.wasNull());
                 assertTrue(rs.next());
                 assertEquals(rs.getInt(1), 49);
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    public static void test_appender_array_basic_varchar() throws Exception {
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 VARCHAR[2])");
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                appender.beginRow()
+                    .append(42)
+                    .append(asList("foo", "barbazboo0123456789"))
+                    .endRow()
+                    .beginRow()
+                    .append(43)
+                    .append((List<Object>) null)
+                    .endRow()
+                    .beginRow()
+                    .append(44)
+                    .append(asList(null, "bar"))
+                    .endRow()
+                    .flush();
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 42")) {
+                assertTrue(rs.next());
+                assertEquals(rs.getString(1), "foo");
+                assertTrue(rs.next());
+                assertEquals(rs.getString(1), "barbazboo0123456789");
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT col2 from tab1 WHERE col1 = 43")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 44")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertTrue(rs.next());
+                assertEquals(rs.getString(1), "bar");
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    public static void test_appender_list_basic_varchar() throws Exception {
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 VARCHAR[])");
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                appender.beginRow()
+                    .append(42)
+                    .append(asList("foo", "barbazboo0123456789", "bar"))
+                    .endRow()
+                    .beginRow()
+                    .append(43)
+                    .append((List<Object>) null)
+                    .endRow()
+                    .beginRow()
+                    .append(44)
+                    .append(asList(null, "boo"))
+                    .endRow()
+                    .flush();
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 42")) {
+                assertTrue(rs.next());
+                assertEquals(rs.getString(1), "foo");
+                assertTrue(rs.next());
+                assertEquals(rs.getString(1), "barbazboo0123456789");
+                assertTrue(rs.next());
+                assertEquals(rs.getString(1), "bar");
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT col2 from tab1 WHERE col1 = 43")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 44")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertTrue(rs.next());
+                assertEquals(rs.getString(1), "boo");
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    public static void test_appender_array_varchar() throws Exception {
+        int count = 1 << 11;         // auto flush
+        int tail = 16;               // flushed on close
+        int arrayLen = (1 << 6) + 7; // increase this for stress tests
+
+        for (String ddl : new String[] {"CREATE TABLE tab1(col1 INT, col2 VARCHAR[" + arrayLen + "])",
+                                        "CREATE TABLE tab1(col1 INT, col2 VARCHAR[])"}) {
+            for (boolean inlined : new boolean[] {true, false}) {
+                try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+                     Statement stmt = conn.createStatement()) {
+
+                    stmt.execute(ddl);
+
+                    try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                        appender.setWriteInlinedStrings(inlined);
+                        for (int i = 0; i < count + tail; i++) {
+                            List<String> list = new ArrayList<>();
+                            for (int j = 0; j < arrayLen; j++) {
+                                list.add(String.valueOf(i + j));
+                            }
+                            appender.beginRow().append(i).append(list).endRow();
+                        }
+                    }
+
+                    try (ResultSet rs =
+                             stmt.executeQuery("SELECT col1, col2[" + (arrayLen - 1) + "] FROM tab1 ORDER BY col1")) {
+                        for (int i = 0; i < count + tail; i++) {
+                            assertTrue(rs.next());
+                            assertEquals(rs.getInt(1), i);
+                            assertEquals(rs.getString(2), String.valueOf(i + arrayLen - 2));
+                        }
+                        assertFalse(rs.next());
+                    }
+
+                    int row = count - 2;
+                    try (Statement stmt2 = conn.createStatement();
+                         ResultSet rs2 = stmt2.executeQuery("SELECT unnest(col2) FROM tab1 WHERE col1 = " + row)) {
+                        for (int j = 0; j < arrayLen; j++) {
+                            assertTrue(rs2.next());
+                            assertEquals(rs2.getString(1), String.valueOf(row + j));
+                        }
+                        assertFalse(rs2.next());
+                    }
+                }
+            }
+        }
+    }
+
+    public static void test_appender_list_basic_uuid() throws Exception {
+        UUID uid1 = UUID.fromString("6b9ec4d3-a5e1-45e5-b696-1e599a0e2058");
+        UUID uid2 = UUID.fromString("7bf979fc-0c09-4864-bf40-233e7b1fdea1");
+        UUID uid3 = UUID.fromString("2f2ac3eb-9105-4864-a2e5-e6d9a7311ba6");
+        UUID uid4 = UUID.fromString("3b56451f-691a-4a8d-90ca-1e03479fc38a");
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 UUID[])");
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                appender.beginRow()
+                    .append(42)
+                    .append(asList(uid1, uid2, uid3))
+                    .endRow()
+                    .beginRow()
+                    .append(43)
+                    .append((List<Object>) null)
+                    .endRow()
+                    .beginRow()
+                    .append(44)
+                    .append(asList(null, uid4))
+                    .endRow()
+                    .flush();
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 42")) {
+                assertTrue(rs.next());
+                assertEquals(rs.getObject(1), uid1);
+                assertTrue(rs.next());
+                assertEquals(rs.getObject(1), uid2);
+                assertTrue(rs.next());
+                assertEquals(rs.getObject(1), uid3);
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT col2 from tab1 WHERE col1 = 43")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 44")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertTrue(rs.next());
+                assertEquals(rs.getObject(1), uid4);
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    public static void test_appender_list_basic_date() throws Exception {
+        LocalDate ld1 = LocalDate.of(2020, 12, 1);
+        LocalDate ld2 = LocalDate.of(2020, 12, 2);
+        LocalDate ld3 = LocalDate.of(2020, 12, 3);
+        LocalDate ld4 = LocalDate.of(2020, 12, 4);
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 DATE[])");
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                appender.beginRow()
+                    .append(42)
+                    .append(asList(ld1, ld2, ld3))
+                    .endRow()
+                    .beginRow()
+                    .append(43)
+                    .append((List<Object>) null)
+                    .endRow()
+                    .beginRow()
+                    .append(44)
+                    .append(asList(null, ld4))
+                    .endRow()
+                    .flush();
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 42")) {
+                assertTrue(rs.next());
+                assertEquals(rs.getObject(1), ld1);
+                assertTrue(rs.next());
+                assertEquals(rs.getObject(1), ld2);
+                assertTrue(rs.next());
+                assertEquals(rs.getObject(1), ld3);
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT col2 from tab1 WHERE col1 = 43")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 44")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertTrue(rs.next());
+                assertEquals(rs.getObject(1), ld4);
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    public static void test_appender_list_basic_time() throws Exception {
+        LocalTime lt1 = LocalTime.of(23, 59, 1);
+        LocalTime lt2 = LocalTime.of(23, 59, 2);
+        LocalTime lt3 = LocalTime.of(23, 59, 3);
+        LocalTime lt4 = LocalTime.of(23, 59, 4);
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 TIME[])");
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                appender.beginRow()
+                    .append(42)
+                    .append(asList(lt1, lt2, lt3))
+                    .endRow()
+                    .beginRow()
+                    .append(43)
+                    .append((List<Object>) null)
+                    .endRow()
+                    .beginRow()
+                    .append(44)
+                    .append(asList(null, lt4))
+                    .endRow()
+                    .flush();
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 42")) {
+                assertTrue(rs.next());
+                assertEquals(rs.getObject(1), lt1);
+                assertTrue(rs.next());
+                assertEquals(rs.getObject(1), lt2);
+                assertTrue(rs.next());
+                assertEquals(rs.getObject(1), lt3);
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT col2 from tab1 WHERE col1 = 43")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 44")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertTrue(rs.next());
+                assertEquals(rs.getObject(1), lt4);
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    public static void test_appender_list_basic_tztime() throws Exception {
+        TimeZone defaultTimeZone = TimeZone.getDefault();
+        TimeZone activeTimeZone = TimeZone.getTimeZone("Europe/Sofia");
+        TimeZone.setDefault(activeTimeZone);
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+
+            OffsetTime ot1 = LocalTime.of(23, 59, 1).atOffset(ZoneOffset.ofHours(1));
+            OffsetTime ot2 = LocalTime.of(23, 59, 2).atOffset(ZoneOffset.ofHours(2));
+            OffsetTime ot3 = LocalTime.of(23, 59, 3).atOffset(ZoneOffset.ofHours(3));
+            OffsetTime ot4 = LocalTime.of(23, 59, 4).atOffset(ZoneOffset.ofHours(4));
+
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 TIME WITH TIME ZONE[])");
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                appender.beginRow()
+                    .append(42)
+                    .append(asList(ot1, ot2, ot3))
+                    .endRow()
+                    .beginRow()
+                    .append(43)
+                    .append((List<Object>) null)
+                    .endRow()
+                    .beginRow()
+                    .append(44)
+                    .append(asList(null, ot4))
+                    .endRow()
+                    .flush();
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 42")) {
+                assertTrue(rs.next());
+                assertEquals(rs.getObject(1), ot1);
+                assertTrue(rs.next());
+                assertEquals(rs.getObject(1), ot2);
+                assertTrue(rs.next());
+                assertEquals(rs.getObject(1), ot3);
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT col2 from tab1 WHERE col1 = 43")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 44")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertTrue(rs.next());
+                assertEquals(rs.getObject(1), ot4);
+                assertFalse(rs.next());
+            }
+        } finally {
+            TimeZone.setDefault(defaultTimeZone);
+        }
+    }
+
+    public static void test_appender_list_basic_local_date_time() throws Exception {
+        LocalDateTime ldt1 = LocalDateTime.of(2020, 12, 31, 23, 59, 1);
+        LocalDateTime ldt2 = LocalDateTime.of(2020, 12, 31, 23, 59, 2);
+        LocalDateTime ldt3 = LocalDateTime.of(2020, 12, 31, 23, 59, 3);
+        LocalDateTime ldt4 = LocalDateTime.of(2020, 12, 31, 23, 59, 4);
+
+        for (String ddl : new String[] {"CREATE TABLE tab1(col1 INT, col2 TIMESTAMP[])",
+                                        "CREATE TABLE tab1(col1 INT, col2 TIMESTAMP_S[])",
+                                        "CREATE TABLE tab1(col1 INT, col2 TIMESTAMP_MS[])",
+                                        "CREATE TABLE tab1(col1 INT, col2 TIMESTAMP_NS[])"}) {
+            try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+                 Statement stmt = conn.createStatement()) {
+                stmt.execute(ddl);
+                try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                    appender.beginRow()
+                        .append(42)
+                        .append(asList(ldt1, ldt2, ldt3))
+                        .endRow()
+                        .beginRow()
+                        .append(43)
+                        .append((List<Object>) null)
+                        .endRow()
+                        .beginRow()
+                        .append(44)
+                        .append(asList(null, ldt4))
+                        .endRow()
+                        .flush();
+                }
+
+                try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 42")) {
+                    assertTrue(rs.next());
+                    assertEquals(rs.getObject(1, LocalDateTime.class), ldt1);
+                    assertTrue(rs.next());
+                    assertEquals(rs.getObject(1, LocalDateTime.class), ldt2);
+                    assertTrue(rs.next());
+                    assertEquals(rs.getObject(1, LocalDateTime.class), ldt3);
+                    assertFalse(rs.next());
+                }
+                try (ResultSet rs = stmt.executeQuery("SELECT col2 from tab1 WHERE col1 = 43")) {
+                    assertTrue(rs.next());
+                    assertNull(rs.getObject(1, LocalDateTime.class));
+                    assertTrue(rs.wasNull());
+                    assertFalse(rs.next());
+                }
+                try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 44")) {
+                    assertTrue(rs.next());
+                    assertNull(rs.getObject(1, LocalDateTime.class));
+                    assertTrue(rs.wasNull());
+                    assertTrue(rs.next());
+                    assertEquals(rs.getObject(1, LocalDateTime.class), ldt4);
+                    assertFalse(rs.next());
+                }
+            }
+        }
+    }
+
+    public static void test_appender_list_basic_local_date_time_date() throws Exception {
+        TimeZone defaultTimeZone = TimeZone.getDefault();
+        TimeZone activeTimeZone = TimeZone.getTimeZone("Europe/Sofia");
+        TimeZone.setDefault(activeTimeZone);
+        try {
+            java.util.Date dt1 = Date.from(LocalDateTime.of(2020, 12, 31, 23, 59, 1).toInstant(ZoneOffset.UTC));
+            java.util.Date dt2 = Date.from(LocalDateTime.of(2020, 12, 31, 23, 59, 2).toInstant(ZoneOffset.UTC));
+            java.util.Date dt3 = Date.from(LocalDateTime.of(2020, 12, 31, 23, 59, 3).toInstant(ZoneOffset.UTC));
+            java.util.Date dt4 = Date.from(LocalDateTime.of(2020, 12, 31, 23, 59, 4).toInstant(ZoneOffset.UTC));
+
+            for (String ddl : new String[] {"CREATE TABLE tab1(col1 INT, col2 TIMESTAMP[])",
+                                            "CREATE TABLE tab1(col1 INT, col2 TIMESTAMP_S[])",
+                                            "CREATE TABLE tab1(col1 INT, col2 TIMESTAMP_MS[])",
+                                            "CREATE TABLE tab1(col1 INT, col2 TIMESTAMP_NS[])"}) {
+                try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+                     Statement stmt = conn.createStatement()) {
+                    stmt.execute(ddl);
+                    try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                        appender.beginRow()
+                            .append(42)
+                            .append(asList(dt1, dt2, dt3))
+                            .endRow()
+                            .beginRow()
+                            .append(43)
+                            .append((List<Object>) null)
+                            .endRow()
+                            .beginRow()
+                            .append(44)
+                            .append(asList(null, dt4))
+                            .endRow()
+                            .flush();
+                    }
+
+                    try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 42")) {
+                        assertTrue(rs.next());
+                        assertEquals(Date.from(rs.getObject(1, LocalDateTime.class).toInstant(ZoneOffset.UTC)), dt1);
+                        assertTrue(rs.next());
+                        assertEquals(Date.from(rs.getObject(1, LocalDateTime.class).toInstant(ZoneOffset.UTC)), dt2);
+                        assertTrue(rs.next());
+                        assertEquals(Date.from(rs.getObject(1, LocalDateTime.class).toInstant(ZoneOffset.UTC)), dt3);
+                        assertFalse(rs.next());
+                    }
+                    try (ResultSet rs = stmt.executeQuery("SELECT col2 from tab1 WHERE col1 = 43")) {
+                        assertTrue(rs.next());
+                        assertNull(rs.getObject(1, LocalDateTime.class));
+                        assertTrue(rs.wasNull());
+                        assertFalse(rs.next());
+                    }
+                    try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 44")) {
+                        assertTrue(rs.next());
+                        assertNull(rs.getObject(1, LocalDateTime.class));
+                        assertTrue(rs.wasNull());
+                        assertTrue(rs.next());
+                        assertEquals(Date.from(rs.getObject(1, LocalDateTime.class).toInstant(ZoneOffset.UTC)), dt4);
+                        assertFalse(rs.next());
+                    }
+                }
+            }
+        } finally {
+            TimeZone.setDefault(defaultTimeZone);
+        }
+    }
+
+    public static void test_appender_list_basic_offset_date_time() throws Exception {
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+
+            OffsetDateTime odt1 = LocalDateTime.of(2020, 12, 31, 23, 59, 1).atOffset(ZoneOffset.UTC);
+            OffsetDateTime odt2 = LocalDateTime.of(2020, 12, 31, 23, 59, 2).atOffset(ZoneOffset.UTC);
+            OffsetDateTime odt3 = LocalDateTime.of(2020, 12, 31, 23, 59, 3).atOffset(ZoneOffset.UTC);
+            OffsetDateTime odt4 = LocalDateTime.of(2020, 12, 31, 23, 59, 4).atOffset(ZoneOffset.UTC);
+
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 TIMESTAMP WITH TIME ZONE[])");
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                appender.beginRow()
+                    .append(42)
+                    .append(asList(odt1, odt2, odt3))
+                    .endRow()
+                    .beginRow()
+                    .append(43)
+                    .append((List<Object>) null)
+                    .endRow()
+                    .beginRow()
+                    .append(44)
+                    .append(asList(null, odt4))
+                    .endRow()
+                    .flush();
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 42")) {
+                assertTrue(rs.next());
+                assertEquals(rs.getObject(1, LocalDateTime.class).getSecond(), odt1.getSecond());
+                assertTrue(rs.next());
+                assertEquals(rs.getObject(1, LocalDateTime.class).getSecond(), odt2.getSecond());
+                assertTrue(rs.next());
+                assertEquals(rs.getObject(1, LocalDateTime.class).getSecond(), odt3.getSecond());
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT col2 from tab1 WHERE col1 = 43")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 44")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertTrue(rs.next());
+                assertEquals(rs.getObject(1, LocalDateTime.class).getSecond(), odt4.getSecond());
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    private static void assertFetchedArrayEquals(Array dba, boolean[] arr) throws Exception {
+        Object[] objArr = (Object[]) dba.getArray();
+        assertEquals(objArr.length, arr.length);
+        for (int i = 0; i < objArr.length; i++) {
+            assertEquals(objArr[i], arr[i]);
+        }
+    }
+
+    public static void test_appender_list_basic_array_bool() throws Exception {
+        boolean[] arr1 = new boolean[] {true, false, true};
+        boolean[] arr2 = new boolean[] {false, true, false};
+        boolean[] arr3 = new boolean[] {false, false, true};
+        boolean[] arr4 = new boolean[] {true, true, false};
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 BOOL[3][])");
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                appender.beginRow()
+                    .append(42)
+                    .append(asList(arr1, arr2, arr3))
+                    .endRow()
+                    .beginRow()
+                    .append(43)
+                    .append((List<Object>) null)
+                    .endRow()
+                    .beginRow()
+                    .append(44)
+                    .append(asList(null, arr4))
+                    .endRow()
+                    .flush();
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 42")) {
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr1);
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr2);
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr3);
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT col2 from tab1 WHERE col1 = 43")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 44")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr4);
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    private static void assertFetchedArrayEquals(Array dba, byte[] arr) throws Exception {
+        Object[] objArr = (Object[]) dba.getArray();
+        assertEquals(objArr.length, arr.length);
+        for (int i = 0; i < objArr.length; i++) {
+            assertEquals(objArr[i], arr[i]);
+        }
+    }
+
+    public static void test_appender_list_basic_array_tinyint() throws Exception {
+        byte[] arr1 = new byte[] {41, 42, 43};
+        byte[] arr2 = new byte[] {45, 46, 47};
+        byte[] arr3 = new byte[] {48, 49, 50};
+        byte[] arr4 = new byte[] {51, 52, 53};
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 TINYINT[3][])");
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                appender.beginRow()
+                    .append(42)
+                    .append(asList(arr1, arr2, arr3))
+                    .endRow()
+                    .beginRow()
+                    .append(43)
+                    .append((List<Object>) null)
+                    .endRow()
+                    .beginRow()
+                    .append(44)
+                    .append(asList(null, arr4))
+                    .endRow()
+                    .flush();
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 42")) {
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr1);
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr2);
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr3);
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT col2 from tab1 WHERE col1 = 43")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 44")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr4);
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    private static void assertFetchedArrayEquals(Array dba, short[] arr) throws Exception {
+        Object[] objArr = (Object[]) dba.getArray();
+        assertEquals(objArr.length, arr.length);
+        for (int i = 0; i < objArr.length; i++) {
+            assertEquals(objArr[i], arr[i]);
+        }
+    }
+
+    public static void test_appender_list_basic_array_smallint() throws Exception {
+        short[] arr1 = new short[] {41, 42, 43};
+        short[] arr2 = new short[] {45, 46, 47};
+        short[] arr3 = new short[] {48, 49, 50};
+        short[] arr4 = new short[] {51, 52, 53};
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 SMALLINT[3][])");
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                appender.beginRow()
+                    .append(42)
+                    .append(asList(arr1, arr2, arr3))
+                    .endRow()
+                    .beginRow()
+                    .append(43)
+                    .append((List<Object>) null)
+                    .endRow()
+                    .beginRow()
+                    .append(44)
+                    .append(asList(null, arr4))
+                    .endRow()
+                    .flush();
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 42")) {
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr1);
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr2);
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr3);
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT col2 from tab1 WHERE col1 = 43")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 44")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr4);
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    private static void assertFetchedArrayEquals(Array dba, int[] arr) throws Exception {
+        Object[] objArr = (Object[]) dba.getArray();
+        assertEquals(objArr.length, arr.length);
+        for (int i = 0; i < objArr.length; i++) {
+            assertEquals(objArr[i], arr[i]);
+        }
+    }
+
+    public static void test_appender_list_basic_array_int() throws Exception {
+        int[] arr1 = new int[] {41, 42, 43};
+        int[] arr2 = new int[] {45, 46, 47};
+        int[] arr3 = new int[] {48, 49, 50};
+        int[] arr4 = new int[] {51, 52, 53};
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 INTEGER[3][])");
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                appender.beginRow()
+                    .append(42)
+                    .append(asList(arr1, arr2, arr3))
+                    .endRow()
+                    .beginRow()
+                    .append(43)
+                    .append((List<Object>) null)
+                    .endRow()
+                    .beginRow()
+                    .append(44)
+                    .append(asList(null, arr4))
+                    .endRow()
+                    .flush();
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 42")) {
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr1);
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr2);
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr3);
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT col2 from tab1 WHERE col1 = 43")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 44")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr4);
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    private static void assertFetchedArrayEquals(Array dba, long[] arr) throws Exception {
+        Object[] objArr = (Object[]) dba.getArray();
+        assertEquals(objArr.length, arr.length);
+        for (int i = 0; i < objArr.length; i++) {
+            assertEquals(objArr[i], arr[i]);
+        }
+    }
+
+    public static void test_appender_list_basic_array_bigint() throws Exception {
+        long[] arr1 = new long[] {41, 42, 43};
+        long[] arr2 = new long[] {45, 46, 47};
+        long[] arr3 = new long[] {48, 49, 50};
+        long[] arr4 = new long[] {51, 52, 53};
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 BIGINT[3][])");
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                appender.beginRow()
+                    .append(42)
+                    .append(asList(arr1, arr2, arr3))
+                    .endRow()
+                    .beginRow()
+                    .append(43)
+                    .append((List<Object>) null)
+                    .endRow()
+                    .beginRow()
+                    .append(44)
+                    .append(asList(null, arr4))
+                    .endRow()
+                    .flush();
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 42")) {
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr1);
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr2);
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr3);
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT col2 from tab1 WHERE col1 = 43")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 44")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr4);
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    private static void assertFetchedArrayEquals(Array dba, float[] arr) throws Exception {
+        Object[] objArr = (Object[]) dba.getArray();
+        assertEquals(objArr.length, arr.length);
+        for (int i = 0; i < objArr.length; i++) {
+            assertEquals(objArr[i], arr[i]);
+        }
+    }
+
+    public static void test_appender_list_basic_array_float() throws Exception {
+        float[] arr1 = new float[] {41, 42, 43};
+        float[] arr2 = new float[] {45, 46, 47};
+        float[] arr3 = new float[] {48, 49, 50};
+        float[] arr4 = new float[] {51, 52, 53};
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 FLOAT[3][])");
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                appender.beginRow()
+                    .append(42)
+                    .append(asList(arr1, arr2, arr3))
+                    .endRow()
+                    .beginRow()
+                    .append(43)
+                    .append((List<Object>) null)
+                    .endRow()
+                    .beginRow()
+                    .append(44)
+                    .append(asList(null, arr4))
+                    .endRow()
+                    .flush();
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 42")) {
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr1);
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr2);
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr3);
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT col2 from tab1 WHERE col1 = 43")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 44")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr4);
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    private static void assertFetchedArrayEquals(Array dba, double[] arr) throws Exception {
+        Object[] objArr = (Object[]) dba.getArray();
+        assertEquals(objArr.length, arr.length);
+        for (int i = 0; i < objArr.length; i++) {
+            assertEquals(objArr[i], arr[i]);
+        }
+    }
+
+    public static void test_appender_list_basic_array_double() throws Exception {
+        double[] arr1 = new double[] {41, 42, 43};
+        double[] arr2 = new double[] {45, 46, 47};
+        double[] arr3 = new double[] {48, 49, 50};
+        double[] arr4 = new double[] {51, 52, 53};
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 DOUBLE[3][])");
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                appender.beginRow()
+                    .append(42)
+                    .append(asList(arr1, arr2, arr3))
+                    .endRow()
+                    .beginRow()
+                    .append(43)
+                    .append((List<Object>) null)
+                    .endRow()
+                    .beginRow()
+                    .append(44)
+                    .append(asList(null, arr4))
+                    .endRow()
+                    .flush();
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 42")) {
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr1);
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr2);
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr3);
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT col2 from tab1 WHERE col1 = 43")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 44")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr4);
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    private static void assertFetchedListEquals(Array dba, List<?> list) throws Exception {
+        Object[] objArr = (Object[]) dba.getArray();
+        assertEquals(objArr.length, list.size());
+        for (int i = 0; i < objArr.length; i++) {
+            assertEquals(objArr[i], list.get(i));
+        }
+    }
+
+    public static void test_appender_list_basic_nested_list() throws Exception {
+        List<String> list1 = asList("foo1", "bar1", "baz1", "boo1");
+        List<String> list2 = asList("foo2", null, "bar2");
+        List<String> list3 = new ArrayList<>();
+        List<String> list4 = asList("foo4", "bar4");
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 VARCHAR[][])");
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                appender.beginRow()
+                    .append(42)
+                    .append(asList(list1, list2, list3))
+                    .endRow()
+                    .beginRow()
+                    .append(43)
+                    .append((List<Object>) null)
+                    .endRow()
+                    .beginRow()
+                    .append(44)
+                    .append(asList(null, list4))
+                    .endRow()
+                    .flush();
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 42")) {
+                assertTrue(rs.next());
+                assertFetchedListEquals(rs.getArray(1), list1);
+                assertTrue(rs.next());
+                assertFetchedListEquals(rs.getArray(1), list2);
+                assertTrue(rs.next());
+                assertFetchedListEquals(rs.getArray(1), list3);
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT col2 from tab1 WHERE col1 = 43")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 44")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertTrue(rs.next());
+                assertFetchedListEquals(rs.getArray(1), list4);
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    private static void assertMapsEqual(Object obj1, Map<?, ?> map2) throws Exception {
+        Map<?, ?> map1 = (Map<?, ?>) obj1;
+        assertEquals(map1.size(), map2.size());
+        List<Map.Entry<?, ?>> list2 = new ArrayList<>(map2.entrySet());
+        int i = 0;
+        for (Map.Entry<?, ?> en : map1.entrySet()) {
+            assertEquals(en.getKey(), list2.get(i).getKey());
+            assertEquals(en.getValue(), list2.get(i).getValue());
+            i += 1;
+        }
+    }
+
+    public static void test_appender_map_basic() throws Exception {
+        Map<Integer, String> map1 = createMap(41, "foo", 42, "bar");
+        Map<Integer, String> map2 = createMap(41, "foo", 42, null, 43, "baz");
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE tab1(col1 INTEGER, col2 MAP(INTEGER, VARCHAR))");
+
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                appender.beginRow()
+                    .append(41)
+                    .append(map1)
+                    .endRow()
+                    .beginRow()
+                    .append(42)
+                    .append(map2)
+                    .endRow()
+                    .flush();
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT col2 FROM tab1 ORDER BY col1")) {
+                assertTrue(rs.next());
+                assertMapsEqual(rs.getObject(1), map1);
+                assertTrue(rs.next());
+                assertMapsEqual(rs.getObject(1), map2);
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    public static void test_appender_list_basic_map() throws Exception {
+        Map<Integer, String> map1 = createMap(41, "foo1", 42, "bar1", 43, "baz1");
+        Map<Integer, String> map2 = createMap(44, null, 45, "bar2");
+        Map<Integer, String> map3 = new LinkedHashMap<>();
+        Map<Integer, String> map4 = createMap(46, "foo3");
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 MAP(INTEGER, VARCHAR)[])");
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                appender.beginRow()
+                    .append(42)
+                    .append(asList(map1, map2, map3))
+                    .endRow()
+                    .beginRow()
+                    .append(43)
+                    .append((List<Object>) null)
+                    .endRow()
+                    .beginRow()
+                    .append(44)
+                    .append(asList(null, map4))
+                    .endRow()
+                    .flush();
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 42")) {
+                assertTrue(rs.next());
+                assertMapsEqual(rs.getObject(1), map1);
+                assertTrue(rs.next());
+                assertMapsEqual(rs.getObject(1), map2);
+                assertTrue(rs.next());
+                assertMapsEqual(rs.getObject(1), map3);
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT col2 from tab1 WHERE col1 = 43")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 44")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertTrue(rs.next());
+                assertMapsEqual(rs.getObject(1), map4);
                 assertFalse(rs.next());
             }
         }

--- a/src/test/java/org/duckdb/TestAppenderCollection2D.java
+++ b/src/test/java/org/duckdb/TestAppenderCollection2D.java
@@ -1,0 +1,875 @@
+package org.duckdb;
+
+import static java.util.Arrays.asList;
+import static org.duckdb.TestDuckDBJDBC.JDBC_URL;
+import static org.duckdb.test.Assertions.*;
+import static org.duckdb.test.Assertions.assertFalse;
+
+import java.sql.Array;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.List;
+
+public class TestAppenderCollection2D {
+
+    public static void test_appender_nested_array_bool() throws Exception {
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+
+            int count = 1 << 11;         // auto flush
+            int tail = 17;               // flushed on close
+            int arrayLen = (1 << 6) + 5; // increase this for stress tests
+            int childLen = (1 << 6) + 7;
+
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 BOOLEAN[" + childLen + "][" + arrayLen + "])");
+
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                for (int i = 0; i < count + tail; i++) {
+                    boolean[][] arr = new boolean[arrayLen][childLen];
+                    for (int j = 0; j < arrayLen; j++) {
+                        for (int k = 0; k < childLen; k++) {
+                            arr[j][k] = 0 == (i + j + k) % 2;
+                        }
+                    }
+                    appender.beginRow().append(i).append(arr).endRow();
+                }
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT col1, col2[" + (arrayLen - 1) + "][" + (childLen - 1) +
+                                                  "] FROM tab1 ORDER BY col1")) {
+                for (int i = 0; i < count + tail; i++) {
+                    assertTrue(rs.next());
+                    assertEquals(rs.getInt(1), i);
+                    assertEquals(rs.getBoolean(2), 0 == (i + arrayLen + childLen - 4) % 2);
+                }
+                assertFalse(rs.next());
+            }
+
+            int row = count - 2;
+            try (Statement stmt2 = conn.createStatement();
+                 ResultSet rs2 = stmt2.executeQuery(
+                     "SELECT unnest(ucol2) FROM (SELECT unnest(col2) as ucol2 FROM tab1 WHERE col1 = " + row + ")")) {
+                for (int j = 0; j < arrayLen; j++) {
+                    for (int k = 0; k < childLen; k++) {
+                        assertTrue(rs2.next());
+                        assertEquals(rs2.getBoolean(1), 0 == (row + j + k) % 2);
+                    }
+                }
+                assertFalse(rs2.next());
+            }
+        }
+    }
+
+    public static void test_appender_nested_array_tinyint() throws Exception {
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+
+            int count = 1 << 11;         // auto flush
+            int tail = 17;               // flushed on close
+            int arrayLen = (1 << 6) + 5; // increase this for stress tests
+            int childLen = (1 << 6) + 7;
+
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 TINYINT[" + childLen + "][" + arrayLen + "])");
+
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                for (int i = 0; i < count + tail; i++) {
+                    byte[][] arr = new byte[arrayLen][childLen];
+                    for (int j = 0; j < arrayLen; j++) {
+                        for (int k = 0; k < childLen; k++) {
+                            arr[j][k] = (byte) (i + j + k);
+                        }
+                    }
+                    appender.beginRow().append(i).appendByteArray(arr).endRow();
+                }
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT col1, col2[" + (arrayLen - 1) + "][" + (childLen - 1) +
+                                                  "] FROM tab1 ORDER BY col1")) {
+                for (int i = 0; i < count + tail; i++) {
+                    assertTrue(rs.next());
+                    assertEquals(rs.getInt(1), i);
+                    assertEquals(rs.getByte(2), (byte) (i + arrayLen + childLen - 4));
+                }
+                assertFalse(rs.next());
+            }
+
+            int row = count - 2;
+            try (Statement stmt2 = conn.createStatement();
+                 ResultSet rs2 = stmt2.executeQuery(
+                     "SELECT unnest(ucol2) FROM (SELECT unnest(col2) as ucol2 FROM tab1 WHERE col1 = " + row + ")")) {
+                for (int j = 0; j < arrayLen; j++) {
+                    for (int k = 0; k < childLen; k++) {
+                        assertTrue(rs2.next());
+                        assertEquals(rs2.getByte(1), (byte) (row + j + k));
+                    }
+                }
+                assertFalse(rs2.next());
+            }
+        }
+    }
+
+    public static void test_appender_nested_array_smallint() throws Exception {
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+
+            int count = 1 << 11;         // auto flush
+            int tail = 17;               // flushed on close
+            int arrayLen = (1 << 6) + 5; // increase this for stress tests
+            int childLen = (1 << 6) + 7;
+
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 SMALLINT[" + childLen + "][" + arrayLen + "])");
+
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                for (int i = 0; i < count + tail; i++) {
+                    short[][] arr = new short[arrayLen][childLen];
+                    for (int j = 0; j < arrayLen; j++) {
+                        for (int k = 0; k < childLen; k++) {
+                            arr[j][k] = (short) (i + j + k);
+                        }
+                    }
+                    appender.beginRow().append(i).append(arr).endRow();
+                }
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT col1, col2[" + (arrayLen - 1) + "][" + (childLen - 1) +
+                                                  "] FROM tab1 ORDER BY col1")) {
+                for (int i = 0; i < count + tail; i++) {
+                    assertTrue(rs.next());
+                    assertEquals(rs.getInt(1), i);
+                    assertEquals(rs.getShort(2), (short) (i + arrayLen + childLen - 4));
+                }
+                assertFalse(rs.next());
+            }
+
+            int row = count - 2;
+            try (Statement stmt2 = conn.createStatement();
+                 ResultSet rs2 = stmt2.executeQuery(
+                     "SELECT unnest(ucol2) FROM (SELECT unnest(col2) as ucol2 FROM tab1 WHERE col1 = " + row + ")")) {
+                for (int j = 0; j < arrayLen; j++) {
+                    for (int k = 0; k < childLen; k++) {
+                        assertTrue(rs2.next());
+                        assertEquals(rs2.getShort(1), (short) (row + j + k));
+                    }
+                }
+                assertFalse(rs2.next());
+            }
+        }
+    }
+
+    public static void test_appender_nested_array_basic_integer() throws Exception {
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 INTEGER[2][3])");
+
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                appender.beginRow().append(41).append(new int[][] {{42, 43}, {44, 45}, {46, 47}}).endRow();
+                appender.beginRow().append(48).append(new int[][] {{49, 50}, null, {53, 54}}).endRow();
+                appender.beginRow()
+                    .append(55)
+                    .append(new int[][] {{56, 57}, {58, 59}, {60, 61}},
+                            new boolean[][] {{false, true}, {false, false}, {true, false}})
+                    .endRow();
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT col1, unnest(col2) FROM tab1 WHERE col1 = 41")) {
+                assertTrue(rs.next());
+                assertEquals(rs.getInt(1), 41);
+                Object[] array1 = (Object[]) rs.getArray(2).getArray();
+                assertEquals(array1.length, 2);
+                assertEquals(array1[0], 42);
+                assertEquals(array1[1], 43);
+
+                assertTrue(rs.next());
+                assertEquals(rs.getInt(1), 41);
+                Object[] array2 = (Object[]) rs.getArray(2).getArray();
+                assertEquals(array2.length, 2);
+                assertEquals(array2[0], 44);
+                assertEquals(array2[1], 45);
+
+                assertTrue(rs.next());
+                assertEquals(rs.getInt(1), 41);
+                Object[] array3 = (Object[]) rs.getArray(2).getArray();
+                assertEquals(array3.length, 2);
+                assertEquals(array3[0], 46);
+                assertEquals(array3[1], 47);
+
+                assertFalse(rs.next());
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT col1, unnest(col2) FROM tab1 WHERE col1 = 48")) {
+                assertTrue(rs.next());
+                assertEquals(rs.getInt(1), 48);
+                Object[] array1 = (Object[]) rs.getArray(2).getArray();
+                assertEquals(array1.length, 2);
+                assertEquals(array1[0], 49);
+                assertEquals(array1[1], 50);
+
+                assertTrue(rs.next());
+                assertEquals(rs.getInt(1), 48);
+                assertNull(rs.getObject(2));
+
+                assertTrue(rs.next());
+                assertEquals(rs.getInt(1), 48);
+                Object[] array3 = (Object[]) rs.getArray(2).getArray();
+                assertEquals(array3.length, 2);
+                assertEquals(array3[0], 53);
+                assertEquals(array3[1], 54);
+
+                assertFalse(rs.next());
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT col1, unnest(col2) FROM tab1 WHERE col1 = 55")) {
+                assertTrue(rs.next());
+                assertEquals(rs.getInt(1), 55);
+                Object[] array1 = (Object[]) rs.getArray(2).getArray();
+                assertEquals(array1.length, 2);
+                assertEquals(array1[0], 56);
+                assertNull(array1[1]);
+
+                assertTrue(rs.next());
+                assertEquals(rs.getInt(1), 55);
+                Object[] array2 = (Object[]) rs.getArray(2).getArray();
+                assertEquals(array2.length, 2);
+                assertEquals(array2[0], 58);
+                assertEquals(array2[1], 59);
+
+                assertTrue(rs.next());
+                assertEquals(rs.getInt(1), 55);
+                Object[] array3 = (Object[]) rs.getArray(2).getArray();
+                assertEquals(array3.length, 2);
+                assertNull(array3[0]);
+                assertEquals(array3[1], 61);
+
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    public static void test_appender_nested_array_integer() throws Exception {
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+
+            int count = 1 << 12;         // auto flush twice
+            int tail = 17;               // flushed on close
+            int arrayLen = (1 << 6) + 5; // increase this for stress tests
+            int childLen = (1 << 6) + 7;
+
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 INTEGER[" + childLen + "][" + arrayLen + "])");
+
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                for (int i = 0; i < count + tail; i++) {
+                    int[][] arr = new int[arrayLen][childLen];
+                    for (int j = 0; j < arrayLen; j++) {
+                        for (int k = 0; k < childLen; k++) {
+                            arr[j][k] = (i + 1) * (j + 1) * (k + 1);
+                        }
+                    }
+                    appender.beginRow().append(i).append(arr).endRow();
+                }
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT col1, col2[" + (arrayLen - 1) + "][" + (childLen - 1) +
+                                                  "] FROM tab1 ORDER BY col1")) {
+                for (int i = 0; i < count + tail; i++) {
+                    assertTrue(rs.next());
+                    assertEquals(rs.getInt(1), i);
+                    assertEquals(rs.getInt(2), (i + 1) * (arrayLen - 1) * (childLen - 1));
+                }
+                assertFalse(rs.next());
+            }
+
+            int row = count - 2;
+            try (Statement stmt2 = conn.createStatement();
+                 ResultSet rs2 = stmt2.executeQuery(
+                     "SELECT unnest(ucol2) FROM (SELECT unnest(col2) as ucol2 FROM tab1 WHERE col1 = " + row + ")")) {
+                for (int j = 0; j < arrayLen; j++) {
+                    for (int k = 0; k < childLen; k++) {
+                        assertTrue(rs2.next());
+                        assertEquals(rs2.getInt(1), (row + 1) * (j + 1) * (k + 1));
+                    }
+                }
+                assertFalse(rs2.next());
+            }
+        }
+    }
+
+    public static void test_appender_nested_array_bigint() throws Exception {
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+
+            int count = 1 << 11;         // auto flush
+            int tail = 17;               // flushed on close
+            int arrayLen = (1 << 6) + 5; // increase this for stress tests
+            int childLen = (1 << 6) + 7;
+
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 BIGINT[" + childLen + "][" + arrayLen + "])");
+
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                for (int i = 0; i < count + tail; i++) {
+                    long[][] arr = new long[arrayLen][childLen];
+                    for (int j = 0; j < arrayLen; j++) {
+                        for (int k = 0; k < childLen; k++) {
+                            arr[j][k] = (long) (i + 1) * (j + 1) * (k + 1);
+                        }
+                    }
+                    appender.beginRow().append(i).append(arr).endRow();
+                }
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT col1, col2[" + (arrayLen - 1) + "][" + (childLen - 1) +
+                                                  "] FROM tab1 ORDER BY col1")) {
+                for (int i = 0; i < count + tail; i++) {
+                    assertTrue(rs.next());
+                    assertEquals(rs.getInt(1), i);
+                    assertEquals(rs.getLong(2), (long) ((i + 1) * (arrayLen - 1) * (childLen - 1)));
+                }
+                assertFalse(rs.next());
+            }
+
+            int row = count - 2;
+            try (Statement stmt2 = conn.createStatement();
+                 ResultSet rs2 = stmt2.executeQuery(
+                     "SELECT unnest(ucol2) FROM (SELECT unnest(col2) as ucol2 FROM tab1 WHERE col1 = " + row + ")")) {
+                for (int j = 0; j < arrayLen; j++) {
+                    for (int k = 0; k < childLen; k++) {
+                        assertTrue(rs2.next());
+                        assertEquals(rs2.getLong(1), (long) (row + 1) * (j + 1) * (k + 1));
+                    }
+                }
+                assertFalse(rs2.next());
+            }
+        }
+    }
+
+    public static void test_appender_nested_array_float() throws Exception {
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+
+            int count = 1 << 12;         // auto flush twice
+            int tail = 17;               // flushed on close
+            int arrayLen = (1 << 6) + 5; // increase this for stress tests
+            int childLen = (1 << 6) + 7;
+
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 FLOAT[" + childLen + "][" + arrayLen + "])");
+
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                for (int i = 0; i < count + tail; i++) {
+                    float[][] arr = new float[arrayLen][childLen];
+                    for (int j = 0; j < arrayLen; j++) {
+                        for (int k = 0; k < childLen; k++) {
+                            arr[j][k] = (i + 1) * (j + 1) * (k + 1) + 0.001f;
+                        }
+                    }
+                    appender.beginRow().append(i).append(arr).endRow();
+                }
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT col1, col2[" + (arrayLen - 1) + "][" + (childLen - 1) +
+                                                  "] FROM tab1 ORDER BY col1")) {
+                for (int i = 0; i < count + tail; i++) {
+                    assertTrue(rs.next());
+                    assertEquals(rs.getInt(1), i);
+                    assertEquals(rs.getFloat(2), (i + 1) * (arrayLen - 1) * (childLen - 1) + 0.001f);
+                }
+                assertFalse(rs.next());
+            }
+
+            int row = count - 2;
+            try (Statement stmt2 = conn.createStatement();
+                 ResultSet rs2 = stmt2.executeQuery(
+                     "SELECT unnest(ucol2) FROM (SELECT unnest(col2) as ucol2 FROM tab1 WHERE col1 = " + row + ")")) {
+                for (int j = 0; j < arrayLen; j++) {
+                    for (int k = 0; k < childLen; k++) {
+                        assertTrue(rs2.next());
+                        assertEquals(rs2.getFloat(1), (row + 1) * (j + 1) * (k + 1) + 0.001f);
+                    }
+                }
+                assertFalse(rs2.next());
+            }
+        }
+    }
+
+    public static void test_appender_nested_array_double() throws Exception {
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+
+            int count = 1 << 11;         // auto flush
+            int tail = 17;               // flushed on close
+            int arrayLen = (1 << 6) + 5; // increase this for stress tests
+            int childLen = (1 << 6) + 7;
+
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 DOUBLE[" + childLen + "][" + arrayLen + "])");
+
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                for (int i = 0; i < count + tail; i++) {
+                    double[][] arr = new double[arrayLen][childLen];
+                    for (int j = 0; j < arrayLen; j++) {
+                        for (int k = 0; k < childLen; k++) {
+                            arr[j][k] = (i + 1) * (j + 1) * (k + 1) + 0.001;
+                        }
+                    }
+                    appender.beginRow().append(i).append(arr).endRow();
+                }
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT col1, col2[" + (arrayLen - 1) + "][" + (childLen - 1) +
+                                                  "] FROM tab1 ORDER BY col1")) {
+                for (int i = 0; i < count + tail; i++) {
+                    assertTrue(rs.next());
+                    assertEquals(rs.getInt(1), i);
+                    assertEquals(rs.getDouble(2), (i + 1) * (arrayLen - 1) * (childLen - 1) + 0.001);
+                }
+                assertFalse(rs.next());
+            }
+
+            int row = count - 2;
+            try (Statement stmt2 = conn.createStatement();
+                 ResultSet rs2 = stmt2.executeQuery(
+                     "SELECT unnest(ucol2) FROM (SELECT unnest(col2) as ucol2 FROM tab1 WHERE col1 = " + row + ")")) {
+                for (int j = 0; j < arrayLen; j++) {
+                    for (int k = 0; k < childLen; k++) {
+                        assertTrue(rs2.next());
+                        assertEquals(rs2.getDouble(1), (row + 1) * (j + 1) * (k + 1) + 0.001);
+                    }
+                }
+                assertFalse(rs2.next());
+            }
+        }
+    }
+
+    private static void assertFetchedArrayEquals(Array dba, boolean[][] arr) throws Exception {
+        Object[] objArr = (Object[]) dba.getArray();
+        assertEquals(objArr.length, arr.length);
+        for (int i = 0; i < objArr.length; i++) {
+            Array wrapper = (Array) objArr[i];
+            Object[] objArrInner = (Object[]) wrapper.getArray();
+            for (int j = 0; j < objArrInner.length; j++) {
+                assertEquals(objArrInner[j], arr[i][j]);
+            }
+        }
+    }
+
+    public static void test_appender_list_basic_array_bool_2d() throws Exception {
+        boolean[][] arr1 = new boolean[][] {{true, false, true}, {false, true, false}};
+        boolean[][] arr2 = new boolean[][] {{false, true, false}, {true, false, true}};
+        boolean[][] arr3 = new boolean[][] {{true, true, false}, {false, true, true}};
+        boolean[][] arr4 = new boolean[][] {{false, false, true}, {true, false, false}};
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 BOOL[3][2][])");
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                appender.beginRow()
+                    .append(42)
+                    .append(asList(arr1, arr2, arr3))
+                    .endRow()
+                    .beginRow()
+                    .append(43)
+                    .append((List<Object>) null)
+                    .endRow()
+                    .beginRow()
+                    .append(44)
+                    .append(asList(null, arr4))
+                    .endRow()
+                    .flush();
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 42")) {
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr1);
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr2);
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr3);
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT col2 from tab1 WHERE col1 = 43")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 44")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr4);
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    private static void assertFetchedArrayEquals(Array dba, byte[][] arr) throws Exception {
+        Object[] objArr = (Object[]) dba.getArray();
+        assertEquals(objArr.length, arr.length);
+        for (int i = 0; i < objArr.length; i++) {
+            Array wrapper = (Array) objArr[i];
+            Object[] objArrInner = (Object[]) wrapper.getArray();
+            for (int j = 0; j < objArrInner.length; j++) {
+                assertEquals(objArrInner[j], arr[i][j]);
+            }
+        }
+    }
+
+    public static void test_appender_list_basic_array_tinyint_2d() throws Exception {
+        byte[][] arr1 = new byte[][] {{41, 42, 43}, {44, 45, 46}};
+        byte[][] arr2 = new byte[][] {{51, 52, 53}, {54, 55, 56}};
+        byte[][] arr3 = new byte[][] {{61, 62, 63}, {64, 65, 66}};
+        byte[][] arr4 = new byte[][] {{71, 72, 73}, {74, 75, 76}};
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 TINYINT[3][2][])");
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                appender.beginRow()
+                    .append(42)
+                    .append(asList(arr1, arr2, arr3))
+                    .endRow()
+                    .beginRow()
+                    .append(43)
+                    .append((List<Object>) null)
+                    .endRow()
+                    .beginRow()
+                    .append(44)
+                    .append(asList(null, arr4))
+                    .endRow()
+                    .flush();
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 42")) {
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr1);
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr2);
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr3);
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT col2 from tab1 WHERE col1 = 43")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 44")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr4);
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    private static void assertFetchedArrayEquals(Array dba, short[][] arr) throws Exception {
+        Object[] objArr = (Object[]) dba.getArray();
+        assertEquals(objArr.length, arr.length);
+        for (int i = 0; i < objArr.length; i++) {
+            Array wrapper = (Array) objArr[i];
+            Object[] objArrInner = (Object[]) wrapper.getArray();
+            for (int j = 0; j < objArrInner.length; j++) {
+                assertEquals(objArrInner[j], arr[i][j]);
+            }
+        }
+    }
+
+    public static void test_appender_list_basic_array_smallint_2d() throws Exception {
+        short[][] arr1 = new short[][] {{41, 42, 43}, {44, 45, 46}};
+        short[][] arr2 = new short[][] {{51, 52, 53}, {54, 55, 56}};
+        short[][] arr3 = new short[][] {{61, 62, 63}, {64, 65, 66}};
+        short[][] arr4 = new short[][] {{71, 72, 73}, {74, 75, 76}};
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 SMALLINT[3][2][])");
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                appender.beginRow()
+                    .append(42)
+                    .append(asList(arr1, arr2, arr3))
+                    .endRow()
+                    .beginRow()
+                    .append(43)
+                    .append((List<Object>) null)
+                    .endRow()
+                    .beginRow()
+                    .append(44)
+                    .append(asList(null, arr4))
+                    .endRow()
+                    .flush();
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 42")) {
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr1);
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr2);
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr3);
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT col2 from tab1 WHERE col1 = 43")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 44")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr4);
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    private static void assertFetchedArrayEquals(Array dba, int[][] arr) throws Exception {
+        Object[] objArr = (Object[]) dba.getArray();
+        assertEquals(objArr.length, arr.length);
+        for (int i = 0; i < objArr.length; i++) {
+            Array wrapper = (Array) objArr[i];
+            Object[] objArrInner = (Object[]) wrapper.getArray();
+            for (int j = 0; j < objArrInner.length; j++) {
+                assertEquals(objArrInner[j], arr[i][j]);
+            }
+        }
+    }
+
+    public static void test_appender_list_basic_array_int_2d() throws Exception {
+        int[][] arr1 = new int[][] {{41, 42, 43}, {44, 45, 46}};
+        int[][] arr2 = new int[][] {{51, 52, 53}, {54, 55, 56}};
+        int[][] arr3 = new int[][] {{61, 62, 63}, {64, 65, 66}};
+        int[][] arr4 = new int[][] {{71, 72, 73}, {74, 75, 76}};
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 INTEGER[3][2][])");
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                appender.beginRow()
+                    .append(42)
+                    .append(asList(arr1, arr2, arr3))
+                    .endRow()
+                    .beginRow()
+                    .append(43)
+                    .append((List<Object>) null)
+                    .endRow()
+                    .beginRow()
+                    .append(44)
+                    .append(asList(null, arr4))
+                    .endRow()
+                    .flush();
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 42")) {
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr1);
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr2);
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr3);
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT col2 from tab1 WHERE col1 = 43")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 44")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr4);
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    private static void assertFetchedArrayEquals(Array dba, long[][] arr) throws Exception {
+        Object[] objArr = (Object[]) dba.getArray();
+        assertEquals(objArr.length, arr.length);
+        for (int i = 0; i < objArr.length; i++) {
+            Array wrapper = (Array) objArr[i];
+            Object[] objArrInner = (Object[]) wrapper.getArray();
+            for (int j = 0; j < objArrInner.length; j++) {
+                assertEquals(objArrInner[j], arr[i][j]);
+            }
+        }
+    }
+
+    public static void test_appender_list_basic_array_bigint_2d() throws Exception {
+        long[][] arr1 = new long[][] {{41, 42, 43}, {44, 45, 46}};
+        long[][] arr2 = new long[][] {{51, 52, 53}, {54, 55, 56}};
+        long[][] arr3 = new long[][] {{61, 62, 63}, {64, 65, 66}};
+        long[][] arr4 = new long[][] {{71, 72, 73}, {74, 75, 76}};
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 BIGINT[3][2][])");
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                appender.beginRow()
+                    .append(42)
+                    .append(asList(arr1, arr2, arr3))
+                    .endRow()
+                    .beginRow()
+                    .append(43)
+                    .append((List<Object>) null)
+                    .endRow()
+                    .beginRow()
+                    .append(44)
+                    .append(asList(null, arr4))
+                    .endRow()
+                    .flush();
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 42")) {
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr1);
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr2);
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr3);
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT col2 from tab1 WHERE col1 = 43")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 44")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr4);
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    private static void assertFetchedArrayEquals(Array dba, float[][] arr) throws Exception {
+        Object[] objArr = (Object[]) dba.getArray();
+        assertEquals(objArr.length, arr.length);
+        for (int i = 0; i < objArr.length; i++) {
+            Array wrapper = (Array) objArr[i];
+            Object[] objArrInner = (Object[]) wrapper.getArray();
+            for (int j = 0; j < objArrInner.length; j++) {
+                assertEquals(objArrInner[j], arr[i][j]);
+            }
+        }
+    }
+
+    public static void test_appender_list_basic_array_float_2d() throws Exception {
+        float[][] arr1 = new float[][] {{41.1F, 42.1F, 43.1F}, {44.1F, 45.1F, 46.1F}};
+        float[][] arr2 = new float[][] {{51.1F, 52.1F, 53.1F}, {54.1F, 55.1F, 56.1F}};
+        float[][] arr3 = new float[][] {{61.1F, 62.1F, 63.1F}, {64.1F, 65.1F, 66.1F}};
+        float[][] arr4 = new float[][] {{71.1F, 72.1F, 73.1F}, {74.1F, 75.1F, 76.1F}};
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 FLOAT[3][2][])");
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                appender.beginRow()
+                    .append(42)
+                    .append(asList(arr1, arr2, arr3))
+                    .endRow()
+                    .beginRow()
+                    .append(43)
+                    .append((List<Object>) null)
+                    .endRow()
+                    .beginRow()
+                    .append(44)
+                    .append(asList(null, arr4))
+                    .endRow()
+                    .flush();
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 42")) {
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr1);
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr2);
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr3);
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT col2 from tab1 WHERE col1 = 43")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 44")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr4);
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    private static void assertFetchedArrayEquals(Array dba, double[][] arr) throws Exception {
+        Object[] objArr = (Object[]) dba.getArray();
+        assertEquals(objArr.length, arr.length);
+        for (int i = 0; i < objArr.length; i++) {
+            Array wrapper = (Array) objArr[i];
+            Object[] objArrInner = (Object[]) wrapper.getArray();
+            for (int j = 0; j < objArrInner.length; j++) {
+                assertEquals(objArrInner[j], arr[i][j]);
+            }
+        }
+    }
+
+    public static void test_appender_list_basic_array_double_2d() throws Exception {
+        double[][] arr1 = new double[][] {{41.1D, 42.1D, 43.1D}, {44.1D, 45.1D, 46.1D}};
+        double[][] arr2 = new double[][] {{51.1D, 52.1D, 53.1D}, {54.1D, 55.1D, 56.1D}};
+        double[][] arr3 = new double[][] {{61.1D, 62.1D, 63.1D}, {64.1D, 65.1D, 66.1D}};
+        double[][] arr4 = new double[][] {{71.1D, 72.1D, 73.1D}, {74.1D, 75.1D, 76.1D}};
+        try (DuckDBConnection conn = DriverManager.getConnection(JDBC_URL).unwrap(DuckDBConnection.class);
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE tab1(col1 INT, col2 DOUBLE[3][2][])");
+            try (DuckDBAppender appender = conn.createAppender("tab1")) {
+                appender.beginRow()
+                    .append(42)
+                    .append(asList(arr1, arr2, arr3))
+                    .endRow()
+                    .beginRow()
+                    .append(43)
+                    .append((List<Object>) null)
+                    .endRow()
+                    .beginRow()
+                    .append(44)
+                    .append(asList(null, arr4))
+                    .endRow()
+                    .flush();
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 42")) {
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr1);
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr2);
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr3);
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT col2 from tab1 WHERE col1 = 43")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("SELECT unnest(col2) from tab1 WHERE col1 = 44")) {
+                assertTrue(rs.next());
+                assertNull(rs.getObject(1));
+                assertTrue(rs.wasNull());
+                assertTrue(rs.next());
+                assertFetchedArrayEquals(rs.getArray(1), arr4);
+                assertFalse(rs.next());
+            }
+        }
+    }
+}

--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -3156,10 +3156,10 @@ public class TestDuckDBJDBC {
             statusCode = runTests(new String[0], clazz);
         } else {
             statusCode = runTests(args, TestDuckDBJDBC.class, TestAppender.class, TestAppenderCollection.class,
-                                  TestAppenderComposite.class, TestSingleValueAppender.class, TestBatch.class,
-                                  TestBindings.class, TestClosure.class, TestExtensionTypes.class, TestSpatial.class,
-                                  TestParameterMetadata.class, TestPrepare.class, TestResults.class,
-                                  TestSessionInit.class, TestTimestamp.class);
+                                  TestAppenderCollection2D.class, TestAppenderComposite.class,
+                                  TestSingleValueAppender.class, TestBatch.class, TestBindings.class, TestClosure.class,
+                                  TestExtensionTypes.class, TestSpatial.class, TestParameterMetadata.class,
+                                  TestPrepare.class, TestResults.class, TestSessionInit.class, TestTimestamp.class);
         }
         System.exit(statusCode);
     }

--- a/src/test/java/org/duckdb/TestParameterMetadata.java
+++ b/src/test/java/org/duckdb/TestParameterMetadata.java
@@ -6,7 +6,7 @@ import static org.duckdb.test.Assertions.assertTrue;
 
 import java.math.BigDecimal;
 import java.sql.*;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 
 public class TestParameterMetadata {
 
@@ -117,7 +117,7 @@ public class TestParameterMetadata {
             try (PreparedStatement ps = conn.prepareStatement("INSERT INTO metadata_test_map_1 VALUES(?)")) {
                 ParameterMetaData meta = ps.getParameterMetaData();
                 assertEquals(meta.getParameterTypeName(1), "MAP(INTEGER, DOUBLE)");
-                assertEquals(meta.getParameterClassName(1), HashMap.class.getName());
+                assertEquals(meta.getParameterClassName(1), LinkedHashMap.class.getName());
                 assertEquals(meta.getPrecision(1), 0);
                 assertEquals(meta.getScale(1), 0);
             }

--- a/src/test/java/org/duckdb/test/Helpers.java
+++ b/src/test/java/org/duckdb/test/Helpers.java
@@ -1,0 +1,15 @@
+package org.duckdb.test;
+
+import java.util.LinkedHashMap;
+
+public class Helpers {
+
+    @SuppressWarnings("unchecked")
+    public static <K, V> LinkedHashMap<K, V> createMap(Object... entries) {
+        LinkedHashMap<K, V> map = new LinkedHashMap<>();
+        for (int i = 0; i < entries.length; i += 2) {
+            map.put((K) entries[i], (V) entries[i + 1]);
+        }
+        return map;
+    }
+}


### PR DESCRIPTION
This is a backport of the PR #399 to `v1.4-andium` stable branch.

This PR adds support for appending to `MAP` and composite `LIST` columns, for example `LIST` of `STRUCT`s, `LIST` of `ARRAY`s or nested `LIST`s.

It should cover virtually any table schema with composite fields, with the notable exception of `ARRAY`s with more than 2 dimensions (like `INT[2][3][4]`) - only 2D `ARRAY`s are supported. Higher dimensions could be possible, but the interface for them appeared to be tough to generalize. `LIST`s of `ARRAY`s can be used instead, like `INT[2][3][]`.

`LIST`s can be specified as a `Collection` or `Iterator` (with `count`) of objects.

`MAP`s are specified as `java.util.Map` instances.

`STRUCT` inside a `LIST` can be specified either as `java.utils.LinkedHashMap` (keys are ignored) or as a `Collection` of values for `STRUCT` fields.

`UNION` inside a `LIST` can be specified as an instance of `java.util.AbstractMap.SimpleEntry`, where a `key` is used as a tag to choose which `UNION` field to append to.

If some required input cases are missed - please raise an issue.

Testing: new tests added to cover various combinations of nesting.

Fixes: #307, #344