### PR TITLE
Update vendored DuckDB sources to f707ac5f0a

### DIFF
--- a/src/duckdb/src/function/table/version/pragma_version.cpp
+++ b/src/duckdb/src/function/table/version/pragma_version.cpp
@@ -1,5 +1,5 @@
 #ifndef DUCKDB_PATCH_VERSION
-#define DUCKDB_PATCH_VERSION "2-dev54"
+#define DUCKDB_PATCH_VERSION "2-dev56"
 #endif
 #ifndef DUCKDB_MINOR_VERSION
 #define DUCKDB_MINOR_VERSION 4
@@ -8,10 +8,10 @@
 #define DUCKDB_MAJOR_VERSION 1
 #endif
 #ifndef DUCKDB_VERSION
-#define DUCKDB_VERSION "v1.4.2-dev54"
+#define DUCKDB_VERSION "v1.4.2-dev56"
 #endif
 #ifndef DUCKDB_SOURCE_ID
-#define DUCKDB_SOURCE_ID "abd077cd1e"
+#define DUCKDB_SOURCE_ID "f707ac5f0a"
 #endif
 #include "duckdb/function/table/system_functions.hpp"
 #include "duckdb/main/database.hpp"


### PR DESCRIPTION
Changes:
 - [duckdb/duckdb#f707ac5f0a](https://github.com/duckdb/duckdb/commit/f707ac5f0a) imported at 2025-10-12 04:04:55
