### PR TITLE
Link MSVC runtime library statically

### DIFF
--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -463,6 +463,7 @@ jobs:
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          dumpbin.exe /imports build\release\libduckdb_java.so_windows_amd64
           dumpbin.exe /exports build\release\libduckdb_java.so_windows_amd64
 
       - name: Java Tests
@@ -544,15 +545,15 @@ jobs:
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsarm64.bat"
+          dumpbin.exe /imports build\release\libduckdb_java.so_windows_arm64
           dumpbin.exe /exports build\release\libduckdb_java.so_windows_arm64
 
-      # Test runs are failing because windows_arm64 extensions are missing
       - name: Java Tests
         if: ${{ inputs.skip_tests != 'true' }}
         shell: bash
         run: |
           java -version
-          make test || true
+          make test
 
       - name: Deploy
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ cmake_minimum_required(VERSION 3.5...3.29)
 set(CMAKE_CXX_STANDARD "11" CACHE STRING "C++ standard to enforce")
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 if(NOT JNI_FOUND OR NOT Java_FOUND)
   message(FATAL_ERROR "No compatible Java/JNI found")
@@ -634,10 +635,7 @@ target_compile_definitions(duckdb_java PRIVATE
   -DDUCKDB_EXTENSION_AUTOLOAD_DEFAULT
   -DDUCKDB_EXTENSION_AUTOINSTALL_DEFAULT)
 
-if(MSVC)
-  target_compile_definitions(duckdb_java PRIVATE
-    -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
-else()
+if(NOT MSVC)
   target_compile_definitions(duckdb_java PRIVATE
     -DDUCKDB_EXTENSION_JEMALLOC_LINKED)
 endif()

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -11,6 +11,7 @@ cmake_minimum_required(VERSION 3.5...3.29)
 set(CMAKE_CXX_STANDARD "11" CACHE STRING "C++ standard to enforce")
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 if(NOT JNI_FOUND OR NOT Java_FOUND)
   message(FATAL_ERROR "No compatible Java/JNI found")
@@ -152,10 +153,7 @@ target_compile_definitions(duckdb_java PRIVATE
   -DDUCKDB_EXTENSION_AUTOLOAD_DEFAULT
   -DDUCKDB_EXTENSION_AUTOINSTALL_DEFAULT)
 
-if(MSVC)
-  target_compile_definitions(duckdb_java PRIVATE
-    -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
-else()
+if(NOT MSVC)
   target_compile_definitions(duckdb_java PRIVATE
     -DDUCKDB_EXTENSION_JEMALLOC_LINKED)
 endif()


### PR DESCRIPTION
This change makes all CMake targets to use `-MT`/`-MTd` compilation flags for Windows MSVC builds. This way the MSVC runtime library is linked statically and the workaround for VS2019 added in duckdb/duckdb#17991 is no longer necessary.

`extension-ci-tools` PR: duckdb/extension-ci-tools#276

Ref: duckdblabs/duckdb-internal#2036