### PR TITLE
Don't use AWS region name for staging upload

### DIFF
--- a/scripts/upload-assets-to-staging.sh
+++ b/scripts/upload-assets-to-staging.sh
@@ -61,5 +61,5 @@ fi
 
 for var in "${@: 2}"
 do
-    aws s3 cp $var s3://duckdb-staging/$TARGET/$GITHUB_REPOSITORY/$FOLDER/ $DRY_RUN_PARAM --region us-east-2
+    aws s3 cp $var s3://duckdb-staging/$TARGET/$GITHUB_REPOSITORY/$FOLDER/ $DRY_RUN_PARAM
 done


### PR DESCRIPTION
This change removes the region name from the
upload-assets-to-staging.sh script, as AWS region names don't match the CloudFlare ones.

Main repo PR: duckdb/duckdb#19551