### PR TITLE
Maven arch-specific and nolib artifacts

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: DuckDB JDBC Driver
 Bundle-SymbolicName: org.duckdb.duckdb_jdbc
-Bundle-Version: 1.4.0.0
+Bundle-Version: 1.5.0.0
 Bundle-Vendor: DuckDB Labs
 Bundle-Description: A JDBC-compliant driver for the DuckDB data management system
 Bundle-License: https://raw.githubusercontent.com/duckdb/duckdb/main/LICENSE


### PR DESCRIPTION
This change makes the following arch-specific artifacts to be deployed to Maven Central (in addition to the main `duckdb_jdbc-x.x.x.x.jar` that remains unchanged), classifiers:

 - `linux_amd64`
 - `linux_amd64_musl`
 - `linux_arm64`
 - `linux_arm64_musl`
 - `macos_universal`
 - `windows_amd64`
 - `windows_arm64`

 Each arch-specific artifact contains a native library only for this
 particular platform and can be specified in Maven dependencies with the
 following syntax:

 ```xml
 <dependency>
    <groupId>org.duckdb</groupId>
    <artifactId>duckdb_jdbc</artifactId>
    <version>1.x.x.x</version>
    <classifier>linux_amd64_musl</classifier>
</dependency>
 ```

Note that Windows and Linux-musl AArch64 artifacts are renamed from `aarch64` to `arm64` to align with wider DuckDB arch naming.

Additionally an artifact without any native library is deployed with a `nolib` classifier. It is intended to be used with an externally provided native library, see #421 for details.