### PR TITLE
Support loading native lib directly from FS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -560,10 +560,10 @@ file(GLOB_RECURSE JAVA_SRC_FILES src/main/java/org/duckdb/*.java)
 file(GLOB_RECURSE JAVA_TEST_FILES src/test/java/org/duckdb/*.java)
 set(CMAKE_JAVA_COMPILE_FLAGS -encoding utf-8 -g -Xlint:all)
 
-add_jar(duckdb_jdbc ${JAVA_SRC_FILES} META-INF/services/java.sql.Driver
+add_jar(duckdb_jdbc_nolib ${JAVA_SRC_FILES} META-INF/services/java.sql.Driver
         MANIFEST META-INF/MANIFEST.MF
         GENERATE_NATIVE_HEADERS duckdb-native)
-add_jar(duckdb_jdbc_tests ${JAVA_TEST_FILES} INCLUDE_JARS duckdb_jdbc)
+add_jar(duckdb_jdbc_tests ${JAVA_TEST_FILES} INCLUDE_JARS duckdb_jdbc_nolib)
 
 
 # main shared lib compilation
@@ -654,7 +654,10 @@ set_target_properties(duckdb_java PROPERTIES PREFIX "lib")
 
 add_custom_command(
   OUTPUT dummy_jdbc_target
-  DEPENDS duckdb_java duckdb_jdbc duckdb_jdbc_tests
+  DEPENDS duckdb_java duckdb_jdbc_nolib duckdb_jdbc_tests
+  COMMAND ${CMAKE_COMMAND} -E copy
+          duckdb_jdbc_nolib.jar
+          duckdb_jdbc.jar
   COMMAND ${Java_JAR_EXECUTABLE} uf duckdb_jdbc.jar -C
           $<TARGET_FILE_DIR:duckdb_java> $<TARGET_FILE_NAME:duckdb_java>)
 

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -86,10 +86,10 @@ file(GLOB_RECURSE JAVA_SRC_FILES src/main/java/org/duckdb/*.java)
 file(GLOB_RECURSE JAVA_TEST_FILES src/test/java/org/duckdb/*.java)
 set(CMAKE_JAVA_COMPILE_FLAGS -encoding utf-8 -g -Xlint:all)
 
-add_jar(duckdb_jdbc ${JAVA_SRC_FILES} META-INF/services/java.sql.Driver
+add_jar(duckdb_jdbc_nolib ${JAVA_SRC_FILES} META-INF/services/java.sql.Driver
         MANIFEST META-INF/MANIFEST.MF
         GENERATE_NATIVE_HEADERS duckdb-native)
-add_jar(duckdb_jdbc_tests ${JAVA_TEST_FILES} INCLUDE_JARS duckdb_jdbc)
+add_jar(duckdb_jdbc_tests ${JAVA_TEST_FILES} INCLUDE_JARS duckdb_jdbc_nolib)
 
 
 # main shared lib compilation
@@ -180,7 +180,10 @@ set_target_properties(duckdb_java PROPERTIES PREFIX "lib")
 
 add_custom_command(
   OUTPUT dummy_jdbc_target
-  DEPENDS duckdb_java duckdb_jdbc duckdb_jdbc_tests
+  DEPENDS duckdb_java duckdb_jdbc_nolib duckdb_jdbc_tests
+  COMMAND ${CMAKE_COMMAND} -E copy
+          duckdb_jdbc_nolib.jar
+          duckdb_jdbc.jar
   COMMAND ${Java_JAR_EXECUTABLE} uf duckdb_jdbc.jar -C
           $<TARGET_FILE_DIR:duckdb_java> $<TARGET_FILE_NAME:duckdb_java>)
 

--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -3155,11 +3155,12 @@ public class TestDuckDBJDBC {
             Class<?> clazz = Class.forName("org.duckdb." + arg1);
             statusCode = runTests(new String[0], clazz);
         } else {
-            statusCode = runTests(args, TestDuckDBJDBC.class, TestAppender.class, TestAppenderCollection.class,
-                                  TestAppenderCollection2D.class, TestAppenderComposite.class,
-                                  TestSingleValueAppender.class, TestBatch.class, TestBindings.class, TestClosure.class,
-                                  TestExtensionTypes.class, TestSpatial.class, TestParameterMetadata.class,
-                                  TestPrepare.class, TestResults.class, TestSessionInit.class, TestTimestamp.class);
+            statusCode =
+                runTests(args, TestDuckDBJDBC.class, TestAppender.class, TestAppenderCollection.class,
+                         TestAppenderCollection2D.class, TestAppenderComposite.class, TestSingleValueAppender.class,
+                         TestBatch.class, TestBindings.class, TestClosure.class, TestExtensionTypes.class,
+                         TestNoLib.class, TestSpatial.class, TestParameterMetadata.class, TestPrepare.class,
+                         TestResults.class, TestSessionInit.class, TestTimestamp.class);
         }
         System.exit(statusCode);
     }

--- a/src/test/java/org/duckdb/TestNoLib.java
+++ b/src/test/java/org/duckdb/TestNoLib.java
@@ -1,0 +1,91 @@
+package org.duckdb;
+
+import static java.util.Arrays.asList;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.SQLException;
+import org.duckdb.test.TempDirectory;
+
+public class TestNoLib {
+
+    private static Path javaExe() {
+        String javaHomeProp = System.getProperty("java.home");
+        Path javaHome = Paths.get(javaHomeProp);
+        boolean isWindows = "windows".equals(DuckDBNative.osName());
+        return isWindows ? javaHome.resolve("bin/java.exe") : javaHome.resolve("bin/java");
+    }
+
+    private static void runQuickTest(Path currentJarDir) throws Exception {
+        String dir = currentJarDir.toAbsolutePath().toString();
+        ProcessBuilder pb = new ProcessBuilder(javaExe().toAbsolutePath().toString(),
+                                               "-Djava.library.path=" + currentJarDir.toAbsolutePath(), "-cp",
+                                               dir + File.separator + "duckdb_jdbc_tests.jar" + File.pathSeparator +
+                                                   dir + File.separator + "duckdb_jdbc_nolib.jar",
+                                               "org.duckdb.TestDuckDBJDBC", "test_spatial_POINT_2D")
+                                .inheritIO();
+        int code = pb.start().waitFor();
+        if (0 != code) {
+            throw new RuntimeException("Spawned test failure, code: " + code);
+        }
+    }
+
+    private static String platformLibName() throws Exception {
+        String os = DuckDBNative.osName();
+        switch (os) {
+        case "windows":
+            return "duckdb_java.dll";
+        case "osx":
+            return "libduckdb_java.dylib";
+        case "linux":
+            return "libduckdb_java.so";
+        default:
+            throw new SQLException("Unsupported OS: " + os);
+        }
+    }
+    private static Path nativeLibPathInBuildTree(Path buildDir) throws SQLException {
+        String libName = DuckDBNative.nativeLibName();
+        Path libPath = buildDir.resolve(libName);
+        if (Files.exists(libPath)) {
+            return libPath;
+        }
+        for (String subdirName : asList("Release", "Debug", "RelWithDebInfo")) {
+            Path dir = buildDir.resolve(subdirName);
+            Path libPathSubdir = dir.resolve(libName);
+            if (Files.exists(libPathSubdir)) {
+                return libPathSubdir;
+            }
+        }
+        throw new SQLException("Native lib not found in build tree, name: '" + libName + "'");
+    }
+
+    public static void test_nolib_next_to_jar() throws Exception {
+        try (TempDirectory td = new TempDirectory()) {
+            Path dir = DuckDBNative.currentJarDir();
+            Path nativeLib = nativeLibPathInBuildTree(dir);
+            Files.copy(dir.resolve("duckdb_jdbc_nolib.jar"), td.path().resolve("duckdb_jdbc_nolib.jar"));
+            Files.copy(dir.resolve("duckdb_jdbc_tests.jar"), td.path().resolve("duckdb_jdbc_tests.jar"));
+            Files.copy(nativeLib, td.path().resolve(nativeLib.getFileName()));
+            System.out.println();
+            System.out.println("----");
+            runQuickTest(td.path());
+            System.out.println("----");
+        }
+    }
+
+    public static void test_nolib_by_name() throws Exception {
+        try (TempDirectory td = new TempDirectory()) {
+            Path dir = DuckDBNative.currentJarDir();
+            Path nativeLib = nativeLibPathInBuildTree(dir);
+            Files.copy(dir.resolve("duckdb_jdbc_nolib.jar"), td.path().resolve("duckdb_jdbc_nolib.jar"));
+            Files.copy(dir.resolve("duckdb_jdbc_tests.jar"), td.path().resolve("duckdb_jdbc_tests.jar"));
+            Files.copy(nativeLib, td.path().resolve(platformLibName()));
+            System.out.println();
+            System.out.println("----");
+            runQuickTest(td.path());
+            System.out.println("----");
+        }
+    }
+}

--- a/src/test/java/org/duckdb/test/Runner.java
+++ b/src/test/java/org/duckdb/test/Runner.java
@@ -40,7 +40,7 @@ public class Runner {
         boolean anyFailed = false;
         for (Method m : methods) {
             if (m.getName().startsWith("test_")) {
-                if (quick_run && m.getName().startsWith("test_lots_")) {
+                if (quick_run && (m.getName().startsWith("test_lots_") || m.getName().startsWith("test_nolib_"))) {
                     continue;
                 }
                 if (specific_test != null && !m.getName().contains(specific_test)) {


### PR DESCRIPTION
This PR is a continuation of #447 PR to allow using `duckdb_jdbc-x.x.x.x-nolib.jar` along with a JNI native library, that is loaded directly from file system.

It extends the idea from #421 (and supersedes it) implementing the following logic:

1. if the driver JAR has a bundled native library (for current JVM os/arch), then this library will be unpacked to the temporary directory and loaded from there. If the library cannot be unpacked or loaded - there is no fallback to other methods (it is expected that `-nolib` JAR is used for other loading methods)

2. if the driver JAR does not hava a native library bundled inside it, then it will check whether a JNI native libary with the DuckDB internal naming (like `libduckdb_java.so_linux_amd64`) exists in file system next to the driver JAR (in the same directory). If library file is found there - then the driver will attempt to load it. If the file is found in file system, then it is expected that is can be loaded and there is no fallback to loading by name.

3. if the native lib is not found in the same directory, then, like in #421, the driver tries to load it using `duckdb_java` name (that will be translated by JVM to a platform-specific name like `libduckdb_java.so`).

Testing: new test added that covers loading from the same dir and loading by name.

Fixes: #444