### PR TITLE
Add JPMS automatic module name (1.4)

### DIFF
--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -77,6 +77,12 @@ jobs:
         run: |
           nm -gU ./build/release/libduckdb_java.so_linux_amd64
 
+      - name: Check Module Name
+        run: |
+          java \
+            --module-path ./build/release/duckdb_jdbc.jar \
+            -d duckdb.jdbc
+
       - name: JDBC Tests EL8
         if: ${{ inputs.skip_tests != 'true' }}
         run: |

--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -11,3 +11,4 @@ Bundle-ContactAddress: mark@duckdblabs.com
 Bundle-Copyright: Copyright (c) DuckDB Labs
 Export-Package: org.duckdb, org.duckdb.io, org.duckdb.user
 Import-Package: javax.sql, org.osgi.framework;resolution:=optional
+Automatic-Module-Name: duckdb.jdbc


### PR DESCRIPTION
This is a backport of the PR #454 to `v1.4-andium` stable branch.

This PR adds the name `duckdb.jdbc` as an [automatic JPMS module](https://openjdk.org/projects/jigsaw/spec/sotms/#automatic-modules) name to the driver JAR. This makes this name, that was previously derived from the JAR file name, to be stable when the driver is used from modular applications.

Testing: CI test added that checks the module name.

Fixes: #431