### PR TITLE
Return concrete class as conn duplicate (1.4)

### DIFF
--- a/src/main/java/org/duckdb/DuckDBConnection.java
+++ b/src/main/java/org/duckdb/DuckDBConnection.java
@@ -96,13 +96,13 @@ public final class DuckDBConnection implements java.sql.Connection {
         return createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
     }
 
-    public Connection duplicate() throws SQLException {
+    public DuckDBConnection duplicate() throws SQLException {
         checkOpen();
         connRefLock.lock();
         try {
             checkOpen();
-            return new DuckDBConnection(DuckDBNative.duckdb_jdbc_connect(connRef), url, readOnly, sessionInitSQL,
-                                        autoCommit);
+            ByteBuffer dupRef = DuckDBNative.duckdb_jdbc_connect(connRef);
+            return new DuckDBConnection(dupRef, url, readOnly, sessionInitSQL, autoCommit);
         } finally {
             connRefLock.unlock();
         }

--- a/src/test/java/org/duckdb/TestResults.java
+++ b/src/test/java/org/duckdb/TestResults.java
@@ -57,7 +57,7 @@ public class TestResults {
                 assertFalse(rs.next());
             }
             // test duplication
-            try (Connection conn2 = conn.unwrap(DuckDBConnection.class).duplicate();
+            try (DuckDBConnection conn2 = conn.unwrap(DuckDBConnection.class).duplicate();
                  Statement stmt2 = conn2.createStatement(); ResultSet rs_conn2 = stmt2.executeQuery("SELECT 42")) {
                 rs_conn2.next();
                 assertEquals(42, rs_conn2.getInt(1));


### PR DESCRIPTION
This is a backport of the PR #455 to `v1.4-andium` stable branch.

This change makes the `DuckDBConnection#duplicate()` method to return the concrete class instead of the `Connection` interface to not require users to unwrap the result of the call.

Fixes: #434