### PR TITLE
Switch Linux toolchain to GCC 14

### DIFF
--- a/.github/composite-actions/linux-build-docker/action.yml
+++ b/.github/composite-actions/linux-build-docker/action.yml
@@ -25,9 +25,7 @@ runs:
           cat /etc/os-release
           dnf install -y             \
             ccache                   \
-            gcc-toolset-12-gcc-c++   \
             java-1.8.0-openjdk-devel \
             ninja-build
-          source /opt/rh/gcc-toolset-12/enable
           make -C /duckdb release
         "


### PR DESCRIPTION
This change removes the usage of the GCC 12 (from devtoolset) to stay in line with the main DuckDB that made this switch in duckdb/duckdb#20170.