### PR TITLE
Use macos-latest image on CI

### DIFF
--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -574,7 +574,7 @@ jobs:
 
   java-osx-universal:
     name: macOS (Universal)
-    runs-on: macos-14
+    runs-on: macos-latest
     needs: java-linux-amd64
     env:
       GEN: ninja


### PR DESCRIPTION
Following the same change in the engine: duckdb/duckdb#20169