### PR TITLE
Disable Spatial tests

### DIFF
--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -3148,6 +3148,16 @@ public class TestDuckDBJDBC {
         DriverManager.getConnection("jdbc:duckdb:;foo=bar;jdbc_ignore_unsupported_options=yes;", config).close();
     }
 
+    public static void test_extension_excel() throws Exception {
+        // Check whether the Excel extension can be installed and loaded automatically
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT excel_text(1_234_567.897, 'h:mm AM/PM')")) {
+            assertTrue(rs.next());
+            assertEquals(rs.getString(1), "9:31 PM");
+            assertFalse(rs.next());
+        }
+    }
+
     public static void main(String[] args) throws Exception {
         String arg1 = args.length > 0 ? args[0] : "";
         final int statusCode;
@@ -3159,7 +3169,7 @@ public class TestDuckDBJDBC {
                 runTests(args, TestDuckDBJDBC.class, TestAppender.class, TestAppenderCollection.class,
                          TestAppenderCollection2D.class, TestAppenderComposite.class, TestSingleValueAppender.class,
                          TestBatch.class, TestBindings.class, TestClosure.class, TestExtensionTypes.class,
-                         TestNoLib.class, TestSpatial.class, TestParameterMetadata.class, TestPrepare.class,
+                         TestNoLib.class, /* TestSpatial.class,*/ TestParameterMetadata.class, TestPrepare.class,
                          TestResults.class, TestSessionInit.class, TestTimestamp.class);
         }
         System.exit(statusCode);

--- a/src/test/java/org/duckdb/TestNoLib.java
+++ b/src/test/java/org/duckdb/TestNoLib.java
@@ -24,7 +24,7 @@ public class TestNoLib {
                                                "-Djava.library.path=" + currentJarDir.toAbsolutePath(), "-cp",
                                                dir + File.separator + "duckdb_jdbc_tests.jar" + File.pathSeparator +
                                                    dir + File.separator + "duckdb_jdbc_nolib.jar",
-                                               "org.duckdb.TestDuckDBJDBC", "test_spatial_POINT_2D")
+                                               "org.duckdb.TestDuckDBJDBC", "test_extension_excel")
                                 .inheritIO();
         int code = pb.start().waitFor();
         if (0 != code) {


### PR DESCRIPTION
This PR temporary disables the Spatial extension tests to allow the full test suite to run on the latest `main` where Spatial is not currently available.

Additionally it adds a test that uses Excel extension. This test is also used for `duckdb_jdbc_nolib.jar` checks instead of Spatial tests.