### PR TITLE
Add jemalloc placeholder on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -569,6 +569,7 @@ add_jar(duckdb_jdbc_tests ${JAVA_TEST_FILES} INCLUDE_JARS duckdb_jdbc_nolib)
 # main shared lib compilation
 
 if(MSVC)
+  list(APPEND DUCKDB_INCLUDE_DIRS src/windows)
   list(APPEND DUCKDB_SRC_FILES duckdb_java.def)
 else()
   list(APPEND DUCKDB_SRC_FILES ${JEMALLOC_SRC_FILES})

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -95,6 +95,7 @@ add_jar(duckdb_jdbc_tests ${JAVA_TEST_FILES} INCLUDE_JARS duckdb_jdbc_nolib)
 # main shared lib compilation
 
 if(MSVC)
+  list(APPEND DUCKDB_INCLUDE_DIRS src/windows)
   list(APPEND DUCKDB_SRC_FILES duckdb_java.def)
 else()
   list(APPEND DUCKDB_SRC_FILES ${JEMALLOC_SRC_FILES})

--- a/src/windows/jemalloc_extension.hpp
+++ b/src/windows/jemalloc_extension.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "duckdb.hpp"
+
+namespace duckdb {
+
+class JemallocExtension : public Extension {
+public:
+	void Load(ExtensionLoader &) override {};
+	std::string Name() override {
+		return "";
+	};
+	std::string Version() const override {
+		return "";
+	};
+};
+
+} // namespace duckdb


### PR DESCRIPTION
Due to the way how `generated_extension_loader_package_build.cpp` is generated in the latest `main` versions of the engine, it expects to have the same set of linked extensions on all platforms. `jemalloc` extension is not available on Windows, so the JDBC build fails on Windows.

This PR adds an emtpy placeholder for `JemallocExtension` class that is expected by `generated_extension_loader_package_build.cpp` to fix the compilation on Windows.