### PR TITLE
Update vendored DuckDB sources to 041f4cac68

### DIFF
--- a/src/duckdb/src/function/table/version/pragma_version.cpp
+++ b/src/duckdb/src/function/table/version/pragma_version.cpp
@@ -1,5 +1,5 @@
 #ifndef DUCKDB_PATCH_VERSION
-#define DUCKDB_PATCH_VERSION "0-dev5019"
+#define DUCKDB_PATCH_VERSION "0-dev5021"
 #endif
 #ifndef DUCKDB_MINOR_VERSION
 #define DUCKDB_MINOR_VERSION 5
@@ -8,10 +8,10 @@
 #define DUCKDB_MAJOR_VERSION 1
 #endif
 #ifndef DUCKDB_VERSION
-#define DUCKDB_VERSION "v1.5.0-dev5019"
+#define DUCKDB_VERSION "v1.5.0-dev5021"
 #endif
 #ifndef DUCKDB_SOURCE_ID
-#define DUCKDB_SOURCE_ID "43a67ee2be"
+#define DUCKDB_SOURCE_ID "041f4cac68"
 #endif
 #include "duckdb/function/table/system_functions.hpp"
 #include "duckdb/main/database.hpp"


### PR DESCRIPTION
Changes:
 - [duckdb/duckdb#041f4cac68](https://github.com/duckdb/duckdb/commit/041f4cac68) imported at 2025-12-26 04:39:25
