### PR TITLE
Update vendored DuckDB sources to de5283b5b9

### DIFF
--- a/src/duckdb/src/catalog/catalog_search_path.cpp
+++ b/src/duckdb/src/catalog/catalog_search_path.cpp
@@ -283,7 +283,7 @@ void CatalogSearchPath::SetPathsInternal(vector<CatalogSearchEntry> new_paths) {
 	this->set_paths = std::move(new_paths);
 
 	paths.clear();
-	paths.reserve(set_paths.size() + 3);
+	paths.reserve(set_paths.size() + 4);
 	paths.emplace_back(TEMP_CATALOG, DEFAULT_SCHEMA);
 	for (auto &path : set_paths) {
 		paths.push_back(path);

--- a/src/duckdb/src/common/radix_partitioning.cpp
+++ b/src/duckdb/src/common/radix_partitioning.cpp
@@ -90,6 +90,7 @@ struct ComputePartitionIndicesFunctor {
 			UnaryExecutor::Execute<hash_t, hash_t>(hashes, partition_indices, append_count,
 			                                       [&](hash_t hash) { return CONSTANTS::ApplyMask(hash); });
 		} else {
+			partition_indices.SetVectorType(VectorType::FLAT_VECTOR);
 			// We could just slice the "hashes" vector and use the UnaryExecutor
 			// But slicing a dictionary vector causes SelectionData to be allocated
 			// Instead, we just directly compute the partition indices using the selection vectors
@@ -230,6 +231,7 @@ void RadixPartitionedTupleData::ComputePartitionIndices(Vector &row_locations, i
 		utility_vector = make_uniq<Vector>(LogicalType::HASH);
 	}
 	Vector &intermediate = *utility_vector;
+	intermediate.SetVectorType(VectorType::FLAT_VECTOR);
 	partitions[0]->Gather(row_locations, *FlatVector::IncrementalSelectionVector(), count, hash_col_idx, intermediate,
 	                      *FlatVector::IncrementalSelectionVector(), nullptr);
 	RadixBitsSwitch<ComputePartitionIndicesFunctor, void>(radix_bits, intermediate, partition_indices, count,

--- a/src/duckdb/src/execution/radix_partitioned_hashtable.cpp
+++ b/src/duckdb/src/execution/radix_partitioned_hashtable.cpp
@@ -561,6 +561,8 @@ void RadixPartitionedHashTable::Sink(ExecutionContext &context, DataChunk &chunk
 
 void RadixPartitionedHashTable::Combine(ExecutionContext &context, GlobalSinkState &gstate_p,
                                         LocalSinkState &lstate_p) const {
+	// There is some defensive programming in here to try to avoid spurious issues
+	// See duckdblabs/duckdb-internal#6818 for more information
 	auto &gstate = gstate_p.Cast<RadixHTGlobalSinkState>();
 	auto &lstate = lstate_p.Cast<RadixHTLocalSinkState>();
 	if (!lstate.ht) {
@@ -584,6 +586,10 @@ void RadixPartitionedHashTable::Combine(ExecutionContext &context, GlobalSinkSta
 	}
 
 	auto guard = gstate.Lock();
+	if (gstate.finalized) {
+		throw InternalException("RadixPartitionedHashTable: Combine called after Finalize!");
+	}
+
 	if (gstate.uncombined_data) {
 		gstate.uncombined_data->Combine(*lstate.abandoned_data);
 	} else {
@@ -591,10 +597,17 @@ void RadixPartitionedHashTable::Combine(ExecutionContext &context, GlobalSinkSta
 	}
 	gstate.stored_allocators.emplace_back(ht.GetAggregateAllocator());
 	gstate.stored_allocators_size += gstate.stored_allocators.back()->AllocationSize();
+
+	// Eagerly destroy the HT
+	lstate.ht.reset();
 }
 
 void RadixPartitionedHashTable::Finalize(ClientContext &context, GlobalSinkState &gstate_p) const {
 	auto &gstate = gstate_p.Cast<RadixHTGlobalSinkState>();
+	auto guard = gstate.Lock();
+	if (gstate.finalized) {
+		throw InternalException("RadixPartitionedHashTable: Finalize called again!");
+	}
 
 	if (gstate.uncombined_data) {
 		auto &uncombined_data = *gstate.uncombined_data;

--- a/src/duckdb/src/function/table/version/pragma_version.cpp
+++ b/src/duckdb/src/function/table/version/pragma_version.cpp
@@ -1,5 +1,5 @@
 #ifndef DUCKDB_PATCH_VERSION
-#define DUCKDB_PATCH_VERSION "4-dev110"
+#define DUCKDB_PATCH_VERSION "4-dev116"
 #endif
 #ifndef DUCKDB_MINOR_VERSION
 #define DUCKDB_MINOR_VERSION 4
@@ -8,10 +8,10 @@
 #define DUCKDB_MAJOR_VERSION 1
 #endif
 #ifndef DUCKDB_VERSION
-#define DUCKDB_VERSION "v1.4.4-dev110"
+#define DUCKDB_VERSION "v1.4.4-dev116"
 #endif
 #ifndef DUCKDB_SOURCE_ID
-#define DUCKDB_SOURCE_ID "0761d5cc7a"
+#define DUCKDB_SOURCE_ID "de5283b5b9"
 #endif
 #include "duckdb/function/table/system_functions.hpp"
 #include "duckdb/main/database.hpp"


### PR DESCRIPTION
Changes:
 - [duckdb/duckdb#de5283b5b9](https://github.com/duckdb/duckdb/commit/de5283b5b9) imported at 2025-12-31 06:35:51
