### PR TITLE
Update vendored DuckDB sources to 686f25a362

### DIFF
--- a/src/duckdb/src/common/adbc/driver_manager.cpp
+++ b/src/duckdb/src/common/adbc/driver_manager.cpp
@@ -690,7 +690,7 @@ AdbcStatusCode AdbcDatabaseGetOptionBytes(struct AdbcDatabase *database, const c
 	}
 	const auto *args = reinterpret_cast<const TempDatabase *>(database->private_data);
 	const auto it = args->bytes_options.find(key);
-	if (it == args->options.end()) {
+	if (it == args->bytes_options.end()) {
 		return ADBC_STATUS_NOT_FOUND;
 	}
 	const std::string &result = it->second;
@@ -984,13 +984,13 @@ AdbcStatusCode AdbcConnectionGetOptionBytes(struct AdbcConnection *connection, c
 		// Init not yet called, get the saved option
 		const auto *args = reinterpret_cast<const TempConnection *>(connection->private_data);
 		const auto it = args->bytes_options.find(key);
-		if (it == args->options.end()) {
+		if (it == args->bytes_options.end()) {
 			return ADBC_STATUS_NOT_FOUND;
 		}
-		if (*length >= it->second.size() + 1) {
-			std::memcpy(value, it->second.data(), it->second.size() + 1);
+		if (*length >= it->second.size()) {
+			std::memcpy(value, it->second.data(), it->second.size());
 		}
-		*length = it->second.size() + 1;
+		*length = it->second.size();
 		return ADBC_STATUS_OK;
 	}
 	INIT_ERROR(error, connection);

--- a/src/duckdb/src/function/table/version/pragma_version.cpp
+++ b/src/duckdb/src/function/table/version/pragma_version.cpp
@@ -1,5 +1,5 @@
 #ifndef DUCKDB_PATCH_VERSION
-#define DUCKDB_PATCH_VERSION "4-dev120"
+#define DUCKDB_PATCH_VERSION "4-dev123"
 #endif
 #ifndef DUCKDB_MINOR_VERSION
 #define DUCKDB_MINOR_VERSION 4
@@ -8,10 +8,10 @@
 #define DUCKDB_MAJOR_VERSION 1
 #endif
 #ifndef DUCKDB_VERSION
-#define DUCKDB_VERSION "v1.4.4-dev120"
+#define DUCKDB_VERSION "v1.4.4-dev123"
 #endif
 #ifndef DUCKDB_SOURCE_ID
-#define DUCKDB_SOURCE_ID "a5c128a833"
+#define DUCKDB_SOURCE_ID "686f25a362"
 #endif
 #include "duckdb/function/table/system_functions.hpp"
 #include "duckdb/main/database.hpp"


### PR DESCRIPTION
Changes:
 - [duckdb/duckdb#686f25a362](https://github.com/duckdb/duckdb/commit/686f25a362) imported at 2026-01-06 07:37:22
