### PR TITLE
Update vendored DuckDB sources to a56ccd8040

### DIFF
--- a/src/duckdb/src/function/table/version/pragma_version.cpp
+++ b/src/duckdb/src/function/table/version/pragma_version.cpp
@@ -1,5 +1,5 @@
 #ifndef DUCKDB_PATCH_VERSION
-#define DUCKDB_PATCH_VERSION "4-dev173"
+#define DUCKDB_PATCH_VERSION "4-dev175"
 #endif
 #ifndef DUCKDB_MINOR_VERSION
 #define DUCKDB_MINOR_VERSION 4
@@ -8,10 +8,10 @@
 #define DUCKDB_MAJOR_VERSION 1
 #endif
 #ifndef DUCKDB_VERSION
-#define DUCKDB_VERSION "v1.4.4-dev173"
+#define DUCKDB_VERSION "v1.4.4-dev175"
 #endif
 #ifndef DUCKDB_SOURCE_ID
-#define DUCKDB_SOURCE_ID "23dcc0f1f6"
+#define DUCKDB_SOURCE_ID "a56ccd8040"
 #endif
 #include "duckdb/function/table/system_functions.hpp"
 #include "duckdb/main/database.hpp"

--- a/src/duckdb/src/include/duckdb/execution/index/art/prefix.hpp
+++ b/src/duckdb/src/include/duckdb/execution/index/art/prefix.hpp
@@ -25,6 +25,7 @@ public:
 	static constexpr uint8_t ROW_ID_SIZE = sizeof(row_t);
 	static constexpr uint8_t ROW_ID_COUNT = ROW_ID_SIZE - 1;
 	static constexpr uint8_t DEPRECATED_COUNT = 15;
+	// The child pointer and the in_memory boolean.
 	static constexpr uint8_t METADATA_SIZE = sizeof(Node) + 1;
 
 public:


### PR DESCRIPTION
Changes:
 - [duckdb/duckdb#a56ccd8040](https://github.com/duckdb/duckdb/commit/a56ccd8040) imported at 2026-01-10 08:03:21
