### PR TITLE
Update Alpine image to 3.22 (1.4)

### DIFF
--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -311,7 +311,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: java-linux-amd64
     env:
-      ALPINE_IMAGE: alpine:3.21
+      ALPINE_IMAGE: alpine:3.22
     steps:
       - uses: actions/checkout@v4
         with:
@@ -368,7 +368,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     needs: java-linux-amd64
     env:
-      ALPINE_IMAGE: alpine:3.21
+      ALPINE_IMAGE: alpine:3.22
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This is a backport of the PR #523 to `v1.4-andium` stable branch.

Sync with the version of Alpine used in `extension-ci-tools` to build `linux_amd64_musl` extensions - duckdb/extension-ci-tools#291.