### PR TITLE
Support LibreOffice table browser (1.5)

### DIFF
--- a/src/main/java/org/duckdb/DuckDBConnection.java
+++ b/src/main/java/org/duckdb/DuckDBConnection.java
@@ -87,7 +87,8 @@ public final class DuckDBConnection implements java.sql.Connection {
     public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency,
                                               int resultSetHoldability) throws SQLException {
         checkOpen();
-        if (resultSetConcurrency == ResultSet.CONCUR_READ_ONLY && resultSetType == ResultSet.TYPE_FORWARD_ONLY) {
+        if ((resultSetConcurrency == ResultSet.CONCUR_READ_ONLY && resultSetType == ResultSet.TYPE_FORWARD_ONLY) ||
+            readOnly) {
             return new DuckDBPreparedStatement(this, sql);
         }
         throw new SQLFeatureNotSupportedException("prepareStatement");

--- a/src/main/java/org/duckdb/DuckDBDatabaseMetaData.java
+++ b/src/main/java/org/duckdb/DuckDBDatabaseMetaData.java
@@ -721,7 +721,7 @@ public class DuckDBDatabaseMetaData implements DatabaseMetaData {
 
     @Override
     public ResultSet getTableTypes() throws SQLException {
-        String[] tableTypesArray = new String[] {"BASE TABLE", "LOCAL TEMPORARY", "VIEW"};
+        String[] tableTypesArray = new String[] {"TABLE", "LOCAL TEMPORARY", "VIEW"};
         StringBuilder stringBuilder = new StringBuilder(128);
         boolean first = true;
         for (String tableType : tableTypesArray) {
@@ -751,7 +751,9 @@ public class DuckDBDatabaseMetaData implements DatabaseMetaData {
         sb.append("table_catalog AS 'TABLE_CAT'").append(TRAILING_COMMA).append(lineSeparator());
         sb.append("table_schema AS 'TABLE_SCHEM'").append(TRAILING_COMMA).append(lineSeparator());
         sb.append("table_name AS 'TABLE_NAME'").append(TRAILING_COMMA).append(lineSeparator());
-        sb.append("table_type AS 'TABLE_TYPE'").append(TRAILING_COMMA).append(lineSeparator());
+        sb.append("CASE WHEN table_type = 'BASE TABLE' THEN 'TABLE' ELSE table_type END AS 'TABLE_TYPE'")
+            .append(TRAILING_COMMA)
+            .append(lineSeparator());
         sb.append("TABLE_COMMENT AS 'REMARKS'").append(TRAILING_COMMA).append(lineSeparator());
         sb.append("NULL::VARCHAR AS 'TYPE_CAT'").append(TRAILING_COMMA).append(lineSeparator());
         sb.append("NULL::VARCHAR AS 'TYPE_SCHEM'").append(TRAILING_COMMA).append(lineSeparator());
@@ -795,7 +797,8 @@ public class DuckDBDatabaseMetaData implements DatabaseMetaData {
 
         if (types != null && types.length > 0) {
             for (int i = 0; i < types.length; i++) {
-                ps.setString(paramIdx + i, types[i]);
+                String param = "TABLE".equals(types[i]) ? "BASE TABLE" : types[i];
+                ps.setString(paramIdx + i, param);
             }
         }
         ps.closeOnCompletion();

--- a/src/main/java/org/duckdb/JdbcUtils.java
+++ b/src/main/java/org/duckdb/JdbcUtils.java
@@ -31,6 +31,14 @@ final class JdbcUtils {
         return defaultVal;
     }
 
+    static String getOption(Properties props, String opt) {
+        Object obj = props.get(opt);
+        if (null != obj) {
+            return obj.toString().trim();
+        }
+        return null;
+    }
+
     static void setDefaultOptionValue(Properties props, String opt, Object value) {
         if (props.containsKey(opt)) {
             return;

--- a/src/test/java/org/duckdb/TestMetadata.java
+++ b/src/test/java/org/duckdb/TestMetadata.java
@@ -23,11 +23,11 @@ public class TestMetadata {
 
             try (ResultSet rs = dm.getTables(null, null, null, null)) {
                 assertTrue(rs.next());
+                assertEquals(rs.getString("TABLE_NAME"), "b");
+                assertTrue(rs.next());
                 assertEquals(rs.getString("TABLE_NAME"), "a1");
                 assertTrue(rs.next());
                 assertEquals(rs.getString("TABLE_NAME"), "a2");
-                assertTrue(rs.next());
-                assertEquals(rs.getString("TABLE_NAME"), "b");
                 assertTrue(rs.next());
                 assertEquals(rs.getString("TABLE_NAME"), "c");
                 assertFalse(rs.next());
@@ -35,17 +35,17 @@ public class TestMetadata {
 
             try (ResultSet rs = dm.getTables(null, null, null, new String[] {})) {
                 assertTrue(rs.next());
+                assertEquals(rs.getString("TABLE_NAME"), "b");
+                assertTrue(rs.next());
                 assertEquals(rs.getString("TABLE_NAME"), "a1");
                 assertTrue(rs.next());
                 assertEquals(rs.getString("TABLE_NAME"), "a2");
-                assertTrue(rs.next());
-                assertEquals(rs.getString("TABLE_NAME"), "b");
                 assertTrue(rs.next());
                 assertEquals(rs.getString("TABLE_NAME"), "c");
                 assertFalse(rs.next());
             }
 
-            try (ResultSet rs = dm.getTables(null, null, null, new String[] {"BASE TABLE"})) {
+            try (ResultSet rs = dm.getTables(null, null, null, new String[] {"TABLE"})) {
                 assertTrue(rs.next());
                 assertEquals(rs.getString("TABLE_NAME"), "a1");
                 assertTrue(rs.next());
@@ -53,7 +53,7 @@ public class TestMetadata {
                 assertFalse(rs.next());
             }
 
-            try (ResultSet rs = dm.getTables(null, null, null, new String[] {"BASE TABLE", "VIEW"})) {
+            try (ResultSet rs = dm.getTables(null, null, null, new String[] {"TABLE", "VIEW"})) {
                 assertTrue(rs.next());
                 assertEquals(rs.getString("TABLE_NAME"), "a1");
                 assertTrue(rs.next());
@@ -511,8 +511,8 @@ public class TestMetadata {
                 assertEquals(rs.getString(2), DuckDBConnection.DEFAULT_SCHEMA);
                 assertEquals(rs.getString("TABLE_NAME"), "a");
                 assertEquals(rs.getString(3), "a");
-                assertEquals(rs.getString("TABLE_TYPE"), "BASE TABLE");
-                assertEquals(rs.getString(4), "BASE TABLE");
+                assertEquals(rs.getString("TABLE_TYPE"), "TABLE");
+                assertEquals(rs.getString(4), "TABLE");
                 assertEquals(rs.getObject("REMARKS"), "a table");
                 assertEquals(rs.getObject(5), "a table");
                 assertNull(rs.getObject("TYPE_CAT"));
@@ -558,8 +558,8 @@ public class TestMetadata {
                 assertEquals(rs.getString(2), DuckDBConnection.DEFAULT_SCHEMA);
                 assertEquals(rs.getString("TABLE_NAME"), "a");
                 assertEquals(rs.getString(3), "a");
-                assertEquals(rs.getString("TABLE_TYPE"), "BASE TABLE");
-                assertEquals(rs.getString(4), "BASE TABLE");
+                assertEquals(rs.getString("TABLE_TYPE"), "TABLE");
+                assertEquals(rs.getString(4), "TABLE");
                 assertEquals(rs.getObject("REMARKS"), "a table");
                 assertEquals(rs.getObject(5), "a table");
                 assertNull(rs.getObject("TYPE_CAT"));
@@ -793,7 +793,7 @@ public class TestMetadata {
     }
 
     public static void test_get_table_types() throws Exception {
-        String[] tableTypesArray = new String[] {"BASE TABLE", "LOCAL TEMPORARY", "VIEW"};
+        String[] tableTypesArray = new String[] {"TABLE", "LOCAL TEMPORARY", "VIEW"};
         List<String> tableTypesList = new ArrayList<>(asList(tableTypesArray));
         tableTypesList.sort(Comparator.naturalOrder());
 

--- a/src/test/java/org/duckdb/TestPrepare.java
+++ b/src/test/java/org/duckdb/TestPrepare.java
@@ -197,6 +197,23 @@ public class TestPrepare {
         }
     }
 
+    private static void test_prepare_statement_unsupported_types() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
+            conn.prepareStatement("SELECT 42", ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY).close();
+            assertThrows(
+                ()
+                    -> conn.prepareStatement("SELECT 42", ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_READ_ONLY),
+                SQLException.class);
+            assertThrows(
+                ()
+                    -> conn.prepareStatement("SELECT 42", ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_UPDATABLE),
+                SQLException.class);
+        }
+        try (Connection conn = DriverManager.getConnection(JDBC_URL + ";access_mode=READ_ONLY")) {
+            conn.prepareStatement("SELECT 42", ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_UPDATABLE).close();
+        }
+    }
+
     public static void test_bug4218_prepare_types() throws Exception {
         try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
             String query = "SELECT ($1 || $2)";


### PR DESCRIPTION
This is a backport of the PR #569 to `v1.5-variegata` stable branch.

This PR adds support for browsing DuckDB tables using [LibreOffice Base](https://www.libreoffice.org/discover/base/).

The `TABLE_TYPE` column in `DatabaseMetadata#getTables()` is changed from SQL standard `BASE TABLE` to `TABLE` that is required by LibreOffice. This matches the implementation in the PostgreSQL JDBC driver.

Besides that the `access_mode=READ_ONLY` URL parameter now correctly marks the `Connection` as read-only (JDBC-specific option `duckdb.read_only` was required before that).

Testing: existing tests are adjusted, coverage is extended around read-only options handling.

Fixes: #366