### PR TITLE
Support filtering in LibreOffice Base (1.5)

### DIFF
--- a/src/main/java/org/duckdb/DuckDBDriver.java
+++ b/src/main/java/org/duckdb/DuckDBDriver.java
@@ -110,6 +110,9 @@ public class DuckDBDriver implements java.sql.Driver {
         // to be established.
         props.remove("path");
 
+        // LibreOffice Base adds this option with value 'simple'
+        props.remove("Type");
+
         // DuckLake connection
         if (pp.shortUrl.startsWith(DUCKLAKE_URL_PREFIX)) {
             setDefaultOptionValue(props, JDBC_PIN_DB, true);

--- a/src/test/java/org/duckdb/TestMetadata.java
+++ b/src/test/java/org/duckdb/TestMetadata.java
@@ -1015,4 +1015,15 @@ public class TestMetadata {
             }
         }
     }
+
+    public static void test_metadata_type_info() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); ResultSet rs = conn.getMetaData().getTypeInfo()) {
+            // static table, not produced by engine, only checking the count
+            int count = 0;
+            while (rs.next()) {
+                count += 1;
+            }
+            assertEquals(count, 21);
+        }
+    }
 }


### PR DESCRIPTION
This is a backport of the PR #573 to `v1.5-variegata` stable branch.

This PR adds support to column filters in [LibreOffice Base](https://www.libreoffice.org/discover/base/) table browser. It supports all non-composite JDBC types except the temporal types (`DATE`, `TIME`, `TIMESTAMP`). LibreOffice does not use parameters and generate SQL filters for temporal types using [escape sequences](https://docs.oracle.com/cd/E13157_01/wlevs/docs30/jdbc_drivers/sqlescape.html) (for example: `{d '2020-12-31'}`) that are not supported by DuckDB parser.

Ref: #366
Ref: duckdblabs/duckdb-internal#5164