### PR TITLE
Add support for in-core GEOMETRY type (1.5)

### DIFF
--- a/src/jni/duckdb_java.cpp
+++ b/src/jni/duckdb_java.cpp
@@ -622,6 +622,7 @@ jobject ProcessVector(JNIEnv *env, Connection *conn_ref, Vector &vec, idx_t row_
 		break;
 	}
 	case LogicalTypeId::BLOB:
+	case LogicalTypeId::GEOMETRY:
 		varlen_data = env->NewObjectArray(row_count, J_ByteArray, nullptr);
 
 		for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {

--- a/src/main/java/org/duckdb/DuckDBColumnType.java
+++ b/src/main/java/org/duckdb/DuckDBColumnType.java
@@ -37,5 +37,6 @@ public enum DuckDBColumnType {
     ARRAY,
     UNKNOWN,
     UNION,
-    VARIANT;
+    VARIANT,
+    GEOMETRY;
 }

--- a/src/main/java/org/duckdb/DuckDBResultSet.java
+++ b/src/main/java/org/duckdb/DuckDBResultSet.java
@@ -211,6 +211,7 @@ public class DuckDBResultSet implements ResultSet {
             DuckDBColumnType sqlType = meta.column_types[columnIndex - 1];
             switch (sqlType) {
             case BLOB:
+            case GEOMETRY:
             case LIST:
             case STRUCT:
             case MAP:

--- a/src/main/java/org/duckdb/DuckDBResultSetMetaData.java
+++ b/src/main/java/org/duckdb/DuckDBResultSetMetaData.java
@@ -167,6 +167,7 @@ public class DuckDBResultSetMetaData implements ResultSetMetaData {
         case BIT:
             return Types.BIT;
         case BLOB:
+        case GEOMETRY:
             return Types.BLOB;
         default:
             return Types.OTHER;
@@ -356,6 +357,7 @@ public class DuckDBResultSetMetaData implements ResultSetMetaData {
             return 35;
         case VARCHAR:
         case BLOB:
+        case GEOMETRY:
             return Integer.MAX_VALUE;
         default:
             return 0;

--- a/src/main/java/org/duckdb/DuckDBVector.java
+++ b/src/main/java/org/duckdb/DuckDBVector.java
@@ -117,6 +117,7 @@ class DuckDBVector {
         case JSON:
             return getJsonObject(idx);
         case BLOB:
+        case GEOMETRY:
             return getBlob(idx);
         case UUID:
             return getUuid(idx);
@@ -315,7 +316,7 @@ class DuckDBVector {
         if (check_and_null(idx)) {
             return null;
         }
-        if (isType(DuckDBColumnType.BLOB)) {
+        if (isType(DuckDBColumnType.BLOB) || isType(DuckDBColumnType.GEOMETRY)) {
             return new DuckDBResultSet.DuckDBBlobResult(ByteBuffer.wrap((byte[]) varlen_data[idx]));
         }
 
@@ -327,7 +328,7 @@ class DuckDBVector {
             return null;
         }
 
-        if (isType(DuckDBColumnType.BLOB)) {
+        if (isType(DuckDBColumnType.BLOB) || isType(DuckDBColumnType.GEOMETRY)) {
             return (byte[]) varlen_data[idx];
         }
 

--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -2246,9 +2246,9 @@ public class TestDuckDBJDBC {
             statusCode = runTests(args, TestDuckDBJDBC.class, TestAppender.class, TestAppenderCollection.class,
                                   TestAppenderCollection2D.class, TestAppenderComposite.class,
                                   TestSingleValueAppender.class, TestBatch.class, TestBindings.class, TestClosure.class,
-                                  TestExtensionTypes.class, TestMetadata.class, TestNoLib.class,
-                                  /* TestSpatial.class, */ TestParameterMetadata.class, TestPrepare.class,
-                                  TestResults.class, TestSessionInit.class, TestTimestamp.class, TestVariant.class);
+                                  TestExtensionTypes.class, TestMetadata.class, TestNoLib.class, /* TestSpatial.class,*/
+                                  TestParameterMetadata.class, TestPrepare.class, TestResults.class,
+                                  TestSessionInit.class, TestTimestamp.class, TestVariant.class);
         }
         System.exit(statusCode);
     }

--- a/src/test/java/org/duckdb/TestSpatial.java
+++ b/src/test/java/org/duckdb/TestSpatial.java
@@ -279,9 +279,8 @@ public class TestSpatial {
             stmt.executeUpdate("INSTALL spatial");
             stmt.executeUpdate("LOAD spatial");
 
-            byte[] geometryBytes =
-                new byte[] {0,   0,   0,   0,   0,   0,    0,  0,  0,    0,    0,    0,    1,    0,  0,  0,
-                            -51, -52, -52, -52, -52, -116, 68, 64, -102, -103, -103, -103, -103, 25, 69, 64};
+            byte[] geometryBytes = new byte[] {1,  1,  0,    0,    0,    -51,  -52,  -52, -52, -52, -116,
+                                               68, 64, -102, -103, -103, -103, -103, 25,  69,  64};
 
             // GEOMETRY literal
             try (ResultSet rs = stmt.executeQuery("SELECT ST_GeomFromText('POINT(41.1 42.2)')")) {


### PR DESCRIPTION
This is a backport of the PR #577 to `v1.5-variegata` stable branch.

The in-built `GEOMETRY` type was added in 1.5 in addtion to the spatial types/functions that exist in the `duckdb-spatial` extension.

This PR adds support for the new type treating it the same way (as `BLOB`) as the original `GEOMETRY` type from the spatial extension was treated.

Testing: spatial test is effective for the new type, but is currently disabled until the `duckdb-spatial` (that was unavailable for some time) is enabled again in core CI builds.