### PR TITLE
Support building with address sanitizer (1.5)

### DIFF
--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -245,6 +245,99 @@ jobs:
           java -version
           java ${{ github.workspace }}/src/test/external/RunSpark.java spark-test.sql
 
+  java-linux-amd64-asan:
+    name: Linux ASan (amd64)
+    runs-on: ubuntu-latest
+    needs: java-linux-amd64
+    env:
+      GEN: ninja
+      CC: 'ccache gcc'
+      CXX: 'ccache g++'
+      CCACHE_DIR: ${{ github.workspace }}/ccache
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Dependencies
+        run: |
+          echo "set man-db/auto-update false" | sudo debconf-communicate
+          sudo dpkg-reconfigure man-db
+          sudo apt-get update -y -q -o=Dpkg::Use-Pty=0
+          sudo apt-get install -y -q -o=Dpkg::Use-Pty=0 \
+            ccache \
+            ninja-build
+
+      - name: Cache Key
+        id: cache_key
+        run: |
+          DUCKDB_VERSION=$(python ./scripts/print_duckdb_version.py)
+          KEY="${{ runner.os }}-${{ runner.arch }}-$DUCKDB_VERSION"-asan
+          echo "value=${KEY}" >> "${GITHUB_OUTPUT}"
+
+      - name: Restore Cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/ccache
+          key: ${{ steps.cache_key.outputs.value }}
+
+      - name: Build (patched)
+        run: |
+          patch -p1 < ./data/asan/appender_asan_failure.patch
+          git diff HEAD
+          make sanitized
+
+      - name: Save Cache
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/ccache
+          key: ${{ steps.cache_key.outputs.value }} 
+
+      - name: ASan (patched)
+        env:
+          LD_PRELOAD: "/usr/lib/x86_64-linux-gnu/libasan.so.8 /usr/lib/x86_64-linux-gnu/libstdc++.so.6"
+        run: |
+          java \
+            -cp ./build/sanitized/duckdb_jdbc_nolib.jar:./build/sanitized/duckdb_jdbc_tests.jar \
+            org.duckdb.TestDuckDBJDBC \
+            quick \
+            > asan_patched.log 2>&1 \
+            || true
+          cat asan_patched.log
+          grep heap-use-after-free asan_patched.log
+          grep Java_org_duckdb_DuckDBBindings_duckdb_1appender_1create_1ext asan_patched.log
+          grep ABORTING asan_patched.log
+
+      - name: Build
+        run: |
+          git checkout src/jni/bindings_appender.cpp
+          git status
+          make sanitized
+
+      - name: ASan
+        env:
+          LD_PRELOAD: "/usr/lib/x86_64-linux-gnu/libasan.so.8 /usr/lib/x86_64-linux-gnu/libstdc++.so.6"
+        run: |
+          java \
+            -cp ./build/sanitized/duckdb_jdbc_nolib.jar:./build/sanitized/duckdb_jdbc_tests.jar \
+            org.duckdb.TestDuckDBJDBC \
+            quick \
+            > asan.log 2>&1 \
+            || true
+          grep -qPz "TestDuckDBJDBC#test_write_map success in 0 seconds\nOK" asan.log
+          if grep -q ABORTING asan.log; then
+            exit 1
+          fi
+
+      - name: Upload Log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: asan.log
+          path: |
+            asan.log
+
   java-linux-aarch64:
     name: Linux (aarch64)
     runs-on: ubuntu-24.04-arm
@@ -660,6 +753,7 @@ jobs:
       - java-linux-amd64
       - java-linux-amd64-tck
       - java-linux-amd64-spark
+      - java-linux-amd64-asan
       - java-linux-aarch64
       - java-linux-amd64-musl
       - java-linux-aarch64-musl
@@ -737,6 +831,7 @@ jobs:
       - java-linux-amd64
       - java-linux-amd64-tck
       - java-linux-amd64-spark
+      - java-linux-amd64-asan
       - java-linux-aarch64
       - java-linux-amd64-musl
       - java-linux-aarch64-musl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ set(CMAKE_VERBOSE_MAKEFILE OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
+option(ENABLE_ADDRESS_SANITIZER "Enable address sanitizer." FALSE)
+
 if(NOT JNI_FOUND OR NOT Java_FOUND)
   message(FATAL_ERROR "No compatible Java/JNI found")
 endif()
@@ -640,7 +642,7 @@ if(NOT MSVC)
     -DDUCKDB_EXTENSION_JEMALLOC_LINKED)
 endif()
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   target_link_options(duckdb_java PRIVATE
     -Bsymbolic
     -Bsymbolic-functions
@@ -650,6 +652,18 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
   target_link_options(duckdb_java PRIVATE
     -fvisibility=hidden
     -Wl,-exported_symbols_list,${CMAKE_CURRENT_LIST_DIR}/duckdb_java.exp)
+endif()
+
+if(${ENABLE_ADDRESS_SANITIZER})
+  message(STATUS "Address Sanitizer is enabled, run with LD_PRELOAD=\"/path/to/libasan.so.8 /path/to/libstdc++.so.6\"")
+  target_compile_options(duckdb_java PRIVATE
+    -fsanitize=address
+    -g
+    -fno-omit-frame-pointer)
+  if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    target_compile_options(duckdb_java PRIVATE
+      -O2)
+  endif()
 endif()
 
 string(JOIN "_" LIB_SUFFIX ".so" ${OS_NAME} ${OS_ARCH})

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -13,6 +13,8 @@ set(CMAKE_VERBOSE_MAKEFILE OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
+option(ENABLE_ADDRESS_SANITIZER "Enable address sanitizer." FALSE)
+
 if(NOT JNI_FOUND OR NOT Java_FOUND)
   message(FATAL_ERROR "No compatible Java/JNI found")
 endif()
@@ -158,7 +160,7 @@ if(NOT MSVC)
     -DDUCKDB_EXTENSION_JEMALLOC_LINKED)
 endif()
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   target_link_options(duckdb_java PRIVATE
     -Bsymbolic
     -Bsymbolic-functions
@@ -168,6 +170,18 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
   target_link_options(duckdb_java PRIVATE
     -fvisibility=hidden
     -Wl,-exported_symbols_list,${CMAKE_CURRENT_LIST_DIR}/duckdb_java.exp)
+endif()
+
+if(${ENABLE_ADDRESS_SANITIZER})
+  message(STATUS "Address Sanitizer is enabled, run with LD_PRELOAD=\"/path/to/libasan.so.8 /path/to/libstdc++.so.6\"")
+  target_compile_options(duckdb_java PRIVATE
+    -fsanitize=address
+    -g
+    -fno-omit-frame-pointer)
+  if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    target_compile_options(duckdb_java PRIVATE
+      -O2)
+  endif()
 endif()
 
 string(JOIN "_" LIB_SUFFIX ".so" ${OS_NAME} ${OS_ARCH})

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ release:
 	mkdir -p build/release
 	cd build/release && cmake -DCMAKE_BUILD_TYPE=Release $(GENERATOR) $(ARCH_OVERRIDE) ../.. && cmake --build . --config Release
 
+sanitized:
+	mkdir -p build/sanitized
+	cd build/sanitized && cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_ADDRESS_SANITIZER=ON $(GENERATOR) $(ARCH_OVERRIDE) ../.. && cmake --build . --config Release
+
 format:
 	python3 scripts/format.py
 

--- a/data/asan/appender_asan_failure.patch
+++ b/data/asan/appender_asan_failure.patch
@@ -1,0 +1,16 @@
+diff --git a/src/jni/bindings_appender.cpp b/src/jni/bindings_appender.cpp
+index be36ab82..f82a7a56 100644
+--- a/src/jni/bindings_appender.cpp
++++ b/src/jni/bindings_appender.cpp
+@@ -60,6 +60,11 @@ JNIEXPORT jint JNICALL Java_org_duckdb_DuckDBBindings_duckdb_1appender_1create_1
+ 	duckdb_appender appender = nullptr;
+ 
+ 	duckdb_state state = duckdb_appender_create_ext(conn, catalog_ptr, schema_ptr, table_ptr, &appender);
++
++	// asan failure snippet
++	int *x = reinterpret_cast<int*>(malloc(10 * sizeof(int*)));
++	free(x);
++	x[5] = 42;
+ 
+ 	if (state == DuckDBSuccess) {
+ 		jobject appender_ref_buf = env->NewDirectByteBuffer(appender, 0);


### PR DESCRIPTION
This is a backport of the PR #581 to `v1.5-variegata` stable branch.

This PR adds support for building JDBC driver with the [address sanitizer](https://github.com/google/sanitizers/wiki/addresssanitizer) enabled:

```bash
make sanitized
```

To run the sanitized binary `libasan` and `libstdc++` must be preloaded:

```bash
export LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libasan.so.8 /usr/lib/x86_64-linux-gnu/libstdc++.so.6"
```

If we add the following deliberately erratic snippet somewhere inside the JDBC driver:

```c++
int *x = reinterpret_cast<int*>(malloc(10 * sizeof(int*)));
free(x);
std::cout << x[5] << std::endl;
```

Then the execution will abort with something like the following:

```
=================================================================
==114481==ERROR: AddressSanitizer: heap-use-after-free on address 0x7bf5410abf14 at pc 0x7b83372124ac bp 0x7f85413fe070 sp 0x7f85413fe068
READ of size 4 at 0x7bf5410abf14 thread T1
    #0 0x7b83372124ab in _duckdb_jdbc_startup(JNIEnv_*, _jclass*, _jbyteArray*, unsigned char, _jobject*) duckdb-java/src/jni/duckdb_java.cpp:79:18
    #1 0x7b8337239880 in Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1startup duckdb-java/src/jni/functions.cpp:9:30
    #2 0x7b852b3445d9  (<unknown module>)
[...]
==114481==ABORTING
```

Note that on successful run the JVM may print a lot of internal "leak" warnings, it may be necessary to prepare a [suppression file](https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer#suppressions) to prevent this.