### PR TITLE
Support setting Array params with setObject (1.5)

### DIFF
--- a/src/main/java/org/duckdb/DuckDBPreparedStatement.java
+++ b/src/main/java/org/duckdb/DuckDBPreparedStatement.java
@@ -42,6 +42,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import org.duckdb.user.DuckDBUserArray;
 
 public class DuckDBPreparedStatement implements PreparedStatement {
     private DuckDBConnection conn;
@@ -1044,6 +1045,13 @@ public class DuckDBPreparedStatement implements PreparedStatement {
                 setObject(parameterIndex, x);
             } else {
                 throw new SQLException("Can't convert value to timestamp " + x.getClass().toString());
+            }
+            break;
+        case Types.ARRAY:
+            if (x instanceof DuckDBUserArray) {
+                setArray(parameterIndex, (Array) x);
+            } else {
+                throw new SQLException("Can't convert value to array " + x.getClass().toString());
             }
             break;
         default:


### PR DESCRIPTION
This is a backport of the PR #588 to `v1.5-variegata` stable branch.

This PR allows to set `Array` query parameters not only with `setArray()`, but also with `setObject()`.

Testing: new test added

Fixes: #586