### PR TITLE
Update vendored DuckDB sources to 6b2b2bdf63

### DIFF
--- a/src/duckdb/src/function/table/version/pragma_version.cpp
+++ b/src/duckdb/src/function/table/version/pragma_version.cpp
@@ -1,5 +1,5 @@
 #ifndef DUCKDB_PATCH_VERSION
-#define DUCKDB_PATCH_VERSION "5-dev23"
+#define DUCKDB_PATCH_VERSION "5-dev25"
 #endif
 #ifndef DUCKDB_MINOR_VERSION
 #define DUCKDB_MINOR_VERSION 4
@@ -8,10 +8,10 @@
 #define DUCKDB_MAJOR_VERSION 1
 #endif
 #ifndef DUCKDB_VERSION
-#define DUCKDB_VERSION "v1.4.5-dev23"
+#define DUCKDB_VERSION "v1.4.5-dev25"
 #endif
 #ifndef DUCKDB_SOURCE_ID
-#define DUCKDB_SOURCE_ID "43d0af8f3e"
+#define DUCKDB_SOURCE_ID "6b2b2bdf63"
 #endif
 #include "duckdb/function/table/system_functions.hpp"
 #include "duckdb/main/database.hpp"


### PR DESCRIPTION
Changes:
 - [duckdb/duckdb#6b2b2bdf63](https://github.com/duckdb/duckdb/commit/6b2b2bdf63) imported at 2026-03-04 07:28:09
