### PR TITLE
Add big endian support to v1.5

### DIFF
--- a/src/jni/refs.cpp
+++ b/src/jni/refs.cpp
@@ -78,7 +78,7 @@ jmethodID J_DuckStruct_init;
 jclass J_ByteBuffer;
 jmethodID J_ByteBuffer_order;
 jclass J_ByteOrder;
-jobject J_ByteOrder_LITTLE_ENDIAN;
+jobject J_ByteOrder_NATIVE;
 
 jclass J_DuckMap;
 jmethodID J_DuckMap_getSQLTypeName;
@@ -154,6 +154,18 @@ static jfieldID get_field_id(JNIEnv *env, jclass clazz, const std::string &name,
 	jfieldID field_id = env->GetFieldID(clazz, name.c_str(), sig.c_str());
 	check_not_null(field_id, "Field not found, name: [" + name + "], signature: [" + sig + "]");
 	return field_id;
+}
+
+static jobject make_static_method_call_ref(JNIEnv *env, jclass clazz, const std::string &name, const std::string &sig) {
+	jmethodID method_id = get_static_method_id(env, clazz, name, sig);
+	jobject local_ref = env->CallStaticObjectMethod(clazz, method_id);
+	check_not_null(local_ref, "Static method returned null, name: [" + name + "], signature: [" + sig + "]");
+	jobject global_ref = env->NewGlobalRef(local_ref);
+	check_not_null(global_ref,
+	               "Cannot create global ref for static method result, name: [" + name + "], signature: [" + sig + "]");
+	env->DeleteLocalRef(local_ref);
+	global_refs.emplace_back(global_ref);
+	return global_ref;
 }
 
 static jobject make_static_object_field_ref(JNIEnv *env, jclass clazz, const std::string &name,
@@ -278,7 +290,7 @@ void create_refs(JNIEnv *env) {
 	J_ByteBuffer = make_class_ref(env, "java/nio/ByteBuffer");
 	J_ByteBuffer_order = get_method_id(env, J_ByteBuffer, "order", "(Ljava/nio/ByteOrder;)Ljava/nio/ByteBuffer;");
 	J_ByteOrder = make_class_ref(env, "java/nio/ByteOrder");
-	J_ByteOrder_LITTLE_ENDIAN = make_static_object_field_ref(env, J_ByteOrder, "LITTLE_ENDIAN", "Ljava/nio/ByteOrder;");
+	J_ByteOrder_NATIVE = make_static_method_call_ref(env, J_ByteOrder, "nativeOrder", "()Ljava/nio/ByteOrder;");
 
 	J_ProfilerPrintFormat = make_class_ref(env, "org/duckdb/ProfilerPrintFormat");
 	J_ProfilerPrintFormat_QUERY_TREE =

--- a/src/jni/refs.hpp
+++ b/src/jni/refs.hpp
@@ -75,7 +75,7 @@ extern jmethodID J_DuckStruct_init;
 extern jclass J_ByteBuffer;
 extern jmethodID J_ByteBuffer_order;
 extern jclass J_ByteOrder;
-extern jobject J_ByteOrder_LITTLE_ENDIAN;
+extern jobject J_ByteOrder_NATIVE;
 
 extern jclass J_DuckMap;
 extern jmethodID J_DuckMap_getSQLTypeName;

--- a/src/jni/util.cpp
+++ b/src/jni/util.cpp
@@ -144,7 +144,7 @@ jobject make_ptr_buf(JNIEnv *env, void *ptr) {
 jobject make_data_buf(JNIEnv *env, void *data, idx_t len) {
 	if (data != nullptr) {
 		jobject buf = env->NewDirectByteBuffer(data, uint64_to_jlong(len));
-		env->CallObjectMethod(buf, J_ByteBuffer_order, J_ByteOrder_LITTLE_ENDIAN);
+		env->CallObjectMethod(buf, J_ByteBuffer_order, J_ByteOrder_NATIVE);
 		return buf;
 	}
 

--- a/src/main/java/org/duckdb/DuckDBResultSet.java
+++ b/src/main/java/org/duckdb/DuckDBResultSet.java
@@ -465,7 +465,7 @@ public class DuckDBResultSet implements ResultSet {
 
         public DuckDBBlobResult(ByteBuffer buffer_p) {
             buffer_p.position(0);
-            buffer_p.order(ByteOrder.LITTLE_ENDIAN);
+            buffer_p.order(ByteOrder.nativeOrder());
             this.buffer = buffer_p;
         }
 

--- a/src/main/java/org/duckdb/DuckDBVector.java
+++ b/src/main/java/org/duckdb/DuckDBVector.java
@@ -457,7 +457,7 @@ class DuckDBVector {
 
     protected ByteBuffer getbuf(int idx, int typeWidth) {
         ByteBuffer buf = constlen_data;
-        buf.order(ByteOrder.LITTLE_ENDIAN);
+        buf.order(ByteOrder.nativeOrder());
         buf.position(idx * typeWidth);
         return buf;
     }
@@ -505,9 +505,7 @@ class DuckDBVector {
             return 0;
         }
         if (isType(DuckDBColumnType.UTINYINT)) {
-            ByteBuffer buf = ByteBuffer.allocate(2);
-            getbuf(idx, 1).get(buf.array(), 1, 1);
-            return buf.getShort();
+            return (short) Byte.toUnsignedInt(getbuf(idx, 1).get());
         }
         throw new SQLFeatureNotSupportedException("getUint8");
     }
@@ -517,10 +515,7 @@ class DuckDBVector {
             return 0;
         }
         if (isType(DuckDBColumnType.UINTEGER)) {
-            ByteBuffer buf = ByteBuffer.allocate(8);
-            buf.order(ByteOrder.LITTLE_ENDIAN);
-            getbuf(idx, 4).get(buf.array(), 0, 4);
-            return buf.getLong();
+            return Integer.toUnsignedLong(getbuf(idx, 4).getInt());
         }
         throw new SQLFeatureNotSupportedException("getUint32");
     }
@@ -530,10 +525,7 @@ class DuckDBVector {
             return 0;
         }
         if (isType(DuckDBColumnType.USMALLINT)) {
-            ByteBuffer buf = ByteBuffer.allocate(4);
-            buf.order(ByteOrder.LITTLE_ENDIAN);
-            getbuf(idx, 2).get(buf.array(), 0, 2);
-            return buf.getInt();
+            return Short.toUnsignedInt(getbuf(idx, 2).getShort());
         }
         throw new SQLFeatureNotSupportedException("getUint16");
     }
@@ -543,13 +535,10 @@ class DuckDBVector {
             return BigInteger.ZERO;
         }
         if (isType(DuckDBColumnType.UBIGINT)) {
-            byte[] buf_res = new byte[16];
-            byte[] buf = new byte[8];
-            getbuf(idx, 8).get(buf);
-            for (int i = 0; i < 8; i++) {
-                buf_res[i + 8] = buf[7 - i];
-            }
-            return new BigInteger(buf_res);
+            byte[] buf_res = new byte[8];
+            long value = getbuf(idx, 8).getLong();
+            ByteBuffer.wrap(buf_res).putLong(value);
+            return new BigInteger(1, buf_res);
         }
         throw new SQLFeatureNotSupportedException("getUint64");
     }
@@ -601,14 +590,12 @@ class DuckDBVector {
             return BigInteger.ZERO;
         }
         if (isType(DuckDBColumnType.HUGEINT)) {
-            byte[] buf = new byte[16];
-            getbuf(idx, 16).get(buf);
-            for (int i = 0; i < 8; i++) {
-                byte keep = buf[i];
-                buf[i] = buf[15 - i];
-                buf[15 - i] = keep;
-            }
-            return new BigInteger(buf);
+            byte[] buf_res = new byte[16];
+            ByteBuffer buf = getbuf(idx, 16);
+            long lower = buf.getLong();
+            long upper = buf.getLong();
+            ByteBuffer.wrap(buf_res).putLong(upper).putLong(lower);
+            return new BigInteger(buf_res);
         }
         Object o = getObject(idx);
         return new BigInteger(o.toString());
@@ -619,14 +606,12 @@ class DuckDBVector {
             return BigInteger.ZERO;
         }
         if (isType(DuckDBColumnType.UHUGEINT)) {
-            byte[] buf = new byte[16];
-            getbuf(idx, 16).get(buf);
-            for (int i = 0; i < 8; i++) {
-                byte keep = buf[i];
-                buf[i] = buf[15 - i];
-                buf[15 - i] = keep;
-            }
-            return new BigInteger(1, buf);
+            byte[] buf_res = new byte[16];
+            ByteBuffer buf = getbuf(idx, 16);
+            long lower = buf.getLong();
+            long upper = buf.getLong();
+            ByteBuffer.wrap(buf_res).putLong(upper).putLong(lower);
+            return new BigInteger(1, buf_res);
         }
         Object o = getObject(idx);
         return new BigInteger(o.toString());


### PR DESCRIPTION
The PR adds big-endian support to the JDBC driver v1.5.

Big-endian patches landed to DuckDB v1.5 (see https://github.com/duckdb/duckdb/pull/19748 and https://github.com/duckdb/duckdb/pull/20237); but the driver needs several minor updates.
