### PR TITLE
Do not provide custom FS in config

### DIFF
--- a/src/jni/config.cpp
+++ b/src/jni/config.cpp
@@ -81,9 +81,6 @@ static duckdb::Value jobj_to_value(JNIEnv *env, const std::string &key, jobject 
 
 std::unique_ptr<duckdb::DBConfig> create_db_config(JNIEnv *env, jboolean read_only, jobject java_config) {
 	auto config = std::unique_ptr<duckdb::DBConfig>(new duckdb::DBConfig());
-	// Required for setting like 'allowed_directories' that use
-	// file separator when checking the property value.
-	config->file_system = duckdb::make_uniq<duckdb::VirtualFileSystem>();
 	config->SetOptionByName("duckdb_api", "java");
 	config->AddExtensionOption(
 	    "jdbc_stream_results",


### PR DESCRIPTION
Workaround with providing custom FS instance as part of initial DB config is no longer necessary in recent versions. In the past it was necessary to use `allowed_directories` option. This PR removes the custom FS.

Testing: the change is covered by existing test.

Ref: #622