### PR TITLE
Add Jepsen to CI (1.5)

### DIFF
--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -350,6 +350,101 @@ jobs:
           path: |
             asan.log
 
+  java-linux-amd64-jepsen:
+    name: Linux Jepsen (amd64)
+    runs-on: ubuntu-latest
+    needs: java-linux-amd64
+    env:
+      MANYLINUX_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout Jepsen
+        uses: actions/checkout@v4
+        with:
+          repository: jepsen-io/duckdb
+          ref: 95731d970339780b934ac106831d704ce3ad23ba
+          path: jepsen
+
+      - name: Cache Key
+        id: cache_key
+        run: |
+          DUCKDB_VERSION=$(python ./scripts/print_duckdb_version.py)
+          KEY="${{ runner.os }}-${{ runner.arch }}-$DUCKDB_VERSION"
+          echo "value=${KEY}" >> "${GITHUB_OUTPUT}"
+
+      - name: Restore Cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/ccache
+          key: ${{ steps.cache_key.outputs.value }}
+
+      - name: Build
+        uses: ./.github/composite-actions/linux-build-docker
+        with:
+          docker_image: '${{ env.MANYLINUX_IMAGE }}'
+
+      - name: Install Dependencies 
+        run: |
+          echo "set man-db/auto-update false" | sudo debconf-communicate
+          sudo dpkg-reconfigure man-db
+          sudo apt-get update -y -q -o=Dpkg::Use-Pty=0
+          sudo apt-get install -y -q -o=Dpkg::Use-Pty=0 \
+            gnuplot \
+            graphviz \
+            leiningen
+
+      - name: Setup Default Java
+        run: |
+          echo "JAVA_HOME=${JAVA_HOME_21_X64}" >> $GITHUB_ENV
+          echo "${JAVA_HOME_21_X64}/bin" >> $GITHUB_PATH
+          sudo update-alternatives --set java /usr/lib/jvm/java-21-openjdk-amd64/bin/java
+          sudo update-alternatives --set javac /usr/lib/jvm/java-21-openjdk-amd64/bin/javac
+          /usr/bin/java --version
+
+      - name: Install JAR
+        run: |
+          mvn -B -ntp --version
+          mvn -B -ntp install:install-file \
+            -Dfile=${{ github.workspace }}/build/release/duckdb_jdbc.jar \
+            -DgroupId=org.duckdb \
+            -DartifactId=duckdb_jdbc \
+            -Dversion=1-jepsen \
+            -Dpackaging=jar
+
+      - name: Run Jepsen
+        working-directory: jepsen
+        run: |
+          patch -p1 < ${{ github.workspace }}/data/jepsen/jepsen.patch
+          lein --version
+          lein run test \
+            --time-limit 10 \
+            --max-writes-per-key 8 \
+            --concurrency 5 \
+            --rate 1000 \
+            --log-sql \
+            --upsert merge-into \
+            --duckdb-log \
+            | grep -v '^INFO' \
+            | tee jepsen.log
+          tail -n 1 jepsen.log | grep -q '^Everything looks good!'
+
+      - name: Zip Results
+        if: always()
+        working-directory: jepsen
+        run: |
+          zip -qyr store.zip store
+
+      - name: Upload Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jepsen
+          path: |
+            jepsen/store.zip
+
   java-linux-aarch64:
     name: Linux (aarch64)
     runs-on: ubuntu-24.04-arm
@@ -766,6 +861,7 @@ jobs:
       - java-linux-amd64-tck
       - java-linux-amd64-spark
       - java-linux-amd64-asan
+      - java-linux-amd64-jepsen
       - java-linux-aarch64
       - java-linux-amd64-musl
       - java-linux-aarch64-musl
@@ -849,6 +945,7 @@ jobs:
       - java-linux-amd64-tck
       - java-linux-amd64-spark
       - java-linux-amd64-asan
+      - java-linux-amd64-jepsen
       - java-linux-aarch64
       - java-linux-amd64-musl
       - java-linux-aarch64-musl
@@ -921,6 +1018,7 @@ jobs:
       - java-linux-amd64-tck
       - java-linux-amd64-spark
       - java-linux-amd64-asan
+      - java-linux-amd64-jepsen
       - java-linux-aarch64
       - java-linux-amd64-musl
       - java-linux-aarch64-musl

--- a/data/jepsen/jepsen.patch
+++ b/data/jepsen/jepsen.patch
@@ -1,0 +1,39 @@
+diff --git a/local-node/project.clj b/local-node/project.clj
+index 89480ff..fdc1a64 100644
+--- a/local-node/project.clj
++++ b/local-node/project.clj
+@@ -13,7 +13,7 @@
+                  [org.clj-commons/slingshot "0.13.0"]
+                  [org.clojure/tools.logging "1.3.0"]
+                  [io.jepsen/generator "0.1.1"]
+-                  [org.duckdb/duckdb_jdbc "1.5.0.0"]
++                  [org.duckdb/duckdb_jdbc "1-jepsen"]
+                  ; Fixes a few known issues (not sure what exactly) in 1.5.0.0
+                  ; [org.duckdb/duckdb_jdbc "1.5.1.0-7e03e76d-SNAPSHOT"]
+                  ; Fixes the data corruption issue we found with strings!
+diff --git a/local-node/src/jepsen/duckdb/local_node.clj b/local-node/src/jepsen/duckdb/local_node.clj
+index cbd66a3..bf0d35e 100644
+--- a/local-node/src/jepsen/duckdb/local_node.clj
++++ b/local-node/src/jepsen/duckdb/local_node.clj
+@@ -164,7 +164,7 @@
+           conn (c/open opts)]
+       (info "Options are:\n" (with-out-str (pprint opts)))
+       (setup! conn opts)
+-      (http/run-server (handler conn opts) (select-keys opts [:port]))
++      (http/run-server (handler conn opts) {:port (:port opts) :reuse-address true})
+       (info "Waiting for HTTP requests on port" (:port opts))
+       (while true
+         (Thread/sleep 100000)))
+diff --git a/project.clj b/project.clj
+index 8b280e7..9e85e33 100644
+--- a/project.clj
++++ b/project.clj
+@@ -4,7 +4,7 @@
+   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
+             :url "https://www.eclipse.org/legal/epl-2.0/"}
+   :dependencies [[org.clojure/clojure "1.12.4"]
+-                 [jepsen "0.3.12-SNAPSHOT"]
++                 [jepsen "0.3.11"]
+                  [clj-http "3.13.1"]]
+   :main jepsen.duckdb.cli
+   :repl-options {:init-ns jepsen.duckdb.repl}


### PR DESCRIPTION
This is a backport of the PR #658 to `v1.5-variegata` stable branch.

This PR adds the [DuckDB Jepsen test suite](https://github.com/jepsen-io/duckdb) to test runs on CI.