### PR TITLE
ISSUE-22042: JDBC: fix PIVOT with auto-commit off (multi-statement prepare)

### DIFF
--- a/src/jni/duckdb_java.cpp
+++ b/src/jni/duckdb_java.cpp
@@ -190,7 +190,35 @@ void _duckdb_jdbc_disconnect(JNIEnv *env, jclass, jobject conn_ref_buf) {
 	}
 }
 
+#include "duckdb/common/constants.hpp"
+#include "duckdb/common/enums/statement_type.hpp"
 #include "utf8proc_wrapper.hpp"
+
+namespace {
+
+//! When a query is expanded into several statements (e.g. dynamic PIVOT creating a temp enum, or transaction policy SET
+//! wrappers), the JDBC driver must prepare the statement that actually returns the result set — typically the last
+//! SELECT — not merely the syntactically last statement.
+idx_t FindLastSelectStatementIndex(const duckdb::vector<duckdb::unique_ptr<SQLStatement>> &statements) {
+	for (idx_t i = statements.size(); i > 0; i--) {
+		if (statements[i - 1]->type == StatementType::SELECT_STATEMENT) {
+			return i - 1;
+		}
+	}
+	return DConstants::INVALID_INDEX;
+}
+
+void ExecuteTrailingQueries(ClientContext &context, const duckdb::vector<string> &trailing_queries) {
+	QueryParameters parameters;
+	for (const auto &trailing_sql : trailing_queries) {
+		auto res = context.Query(trailing_sql, parameters);
+		if (res->HasError()) {
+			res->ThrowError();
+		}
+	}
+}
+
+} // namespace
 
 jobject _duckdb_jdbc_prepare(JNIEnv *env, jclass, jobject conn_ref_buf, jbyteArray query_j) {
 	auto conn_ref = get_connection(env, conn_ref_buf);
@@ -205,9 +233,17 @@ jobject _duckdb_jdbc_prepare(JNIEnv *env, jclass, jobject conn_ref_buf, jbyteArr
 		throw InvalidInputException("No statements to execute.");
 	}
 
-	// if there are multiple statements, we directly execute the statements besides the last one
-	// we only return the result of the last statement to the user, unless one of the previous statements fails
-	for (idx_t i = 0; i + 1 < statements.size(); i++) {
+	idx_t prepare_idx = FindLastSelectStatementIndex(statements);
+	if (prepare_idx == DConstants::INVALID_INDEX) {
+		prepare_idx = statements.size() - 1;
+	}
+
+	duckdb::vector<string> trailing_queries;
+	for (idx_t i = prepare_idx + 1; i < statements.size(); i++) {
+		trailing_queries.push_back(statements[i]->ToString());
+	}
+
+	for (idx_t i = 0; i < prepare_idx; i++) {
 		auto res = conn_ref->Query(std::move(statements[i]));
 		if (res->HasError()) {
 			res->ThrowError();
@@ -215,7 +251,8 @@ jobject _duckdb_jdbc_prepare(JNIEnv *env, jclass, jobject conn_ref_buf, jbyteArr
 	}
 
 	auto stmt_ref = make_uniq<StatementHolder>();
-	stmt_ref->stmt = conn_ref->Prepare(std::move(statements.back()));
+	stmt_ref->stmt = conn_ref->Prepare(std::move(statements[prepare_idx]));
+	stmt_ref->trailing_queries_after_execute = std::move(trailing_queries);
 	if (stmt_ref->stmt->HasError()) {
 		string error_msg = string(stmt_ref->stmt->GetError());
 		stmt_ref->stmt = nullptr;
@@ -238,9 +275,17 @@ jobject _duckdb_jdbc_pending_query(JNIEnv *env, jclass, jobject conn_ref_buf, jb
 		throw InvalidInputException("No statements to execute.");
 	}
 
-	// if there are multiple statements, we directly execute the statements besides the last one
-	// we only return the result of the last statement to the user, unless one of the previous statements fails
-	for (idx_t i = 0; i + 1 < statements.size(); i++) {
+	idx_t prepare_idx = FindLastSelectStatementIndex(statements);
+	if (prepare_idx == DConstants::INVALID_INDEX) {
+		prepare_idx = statements.size() - 1;
+	}
+
+	duckdb::vector<string> trailing_queries;
+	for (idx_t i = prepare_idx + 1; i < statements.size(); i++) {
+		trailing_queries.push_back(statements[i]->ToString());
+	}
+
+	for (idx_t i = 0; i < prepare_idx; i++) {
 		auto res = conn_ref->Query(std::move(statements[i]));
 		if (res->HasError()) {
 			res->ThrowError();
@@ -255,7 +300,9 @@ jobject _duckdb_jdbc_pending_query(JNIEnv *env, jclass, jobject conn_ref_buf, jb
 	    stream_results ? QueryResultOutputType::ALLOW_STREAMING : QueryResultOutputType::FORCE_MATERIALIZED;
 
 	auto pending_ref = make_uniq<PendingHolder>();
-	pending_ref->pending = conn_ref->PendingQuery(std::move(statements.back()), query_parameters);
+	pending_ref->pending = conn_ref->PendingQuery(std::move(statements[prepare_idx]), query_parameters);
+	pending_ref->trailing_queries_after_execute = std::move(trailing_queries);
+	pending_ref->connection_for_trailing = conn_ref;
 
 	return env->NewDirectByteBuffer(pending_ref.release(), 0);
 }
@@ -298,6 +345,13 @@ jobject _duckdb_jdbc_execute(JNIEnv *env, jclass, jobject stmt_ref_buf, jobjectA
 		env->ThrowNew(exc_type, error_msg.c_str());
 		return nullptr;
 	}
+	try {
+		ExecuteTrailingQueries(*stmt_ref->stmt->context, stmt_ref->trailing_queries_after_execute);
+	} catch (const std::exception &ex) {
+		res_ref->res = nullptr;
+		ThrowJNI(env, ex.what());
+		return nullptr;
+	}
 	return env->NewDirectByteBuffer(res_ref.release(), 0);
 }
 
@@ -316,6 +370,21 @@ jobject _duckdb_jdbc_execute_pending(JNIEnv *env, jclass, jobject pending_ref_bu
 		jclass exc_type = duckdb::ExceptionType::INTERRUPT == error_type ? J_SQLTimeoutException : J_SQLException;
 		env->ThrowNew(exc_type, error_msg.c_str());
 		return nullptr;
+	}
+	if (!pending_ref->trailing_queries_after_execute.empty()) {
+		D_ASSERT(pending_ref->connection_for_trailing);
+		try {
+			for (const auto &trailing_sql : pending_ref->trailing_queries_after_execute) {
+				auto tres = pending_ref->connection_for_trailing->Query(trailing_sql);
+				if (tres->HasError()) {
+					tres->ThrowError();
+				}
+			}
+		} catch (const std::exception &ex) {
+			res_ref->res = nullptr;
+			ThrowJNI(env, ex.what());
+			return nullptr;
+		}
 	}
 	return env->NewDirectByteBuffer(res_ref.release(), 0);
 }

--- a/src/jni/holders.hpp
+++ b/src/jni/holders.hpp
@@ -44,10 +44,16 @@ struct ConnectionHolder {
 
 struct StatementHolder {
 	duckdb::unique_ptr<duckdb::PreparedStatement> stmt;
+	//! When the preprocessor expands a statement into several (e.g. PIVOT + transaction policy SETs), we prepare the
+	//! last SELECT and run any trailing statements (typically SET current_transaction_invalidation_policy) after each
+	//! successful execute. Stored as SQL text so repeated execute() on the PreparedStatement remains correct.
+	duckdb::vector<std::string> trailing_queries_after_execute;
 };
 
 struct PendingHolder {
 	duckdb::unique_ptr<duckdb::PendingQueryResult> pending;
+	duckdb::vector<std::string> trailing_queries_after_execute;
+	duckdb::Connection *connection_for_trailing = nullptr;
 };
 
 struct ResultHolder {

--- a/src/main/java/org/duckdb/DuckDBPreparedStatement.java
+++ b/src/main/java/org/duckdb/DuckDBPreparedStatement.java
@@ -148,10 +148,6 @@ public class DuckDBPreparedStatement implements PreparedStatement {
             try {
                 conn.checkOpen();
 
-                if (!isConnAutoCommit()) {
-                    startTransaction();
-                }
-
                 stmtRef = DuckDBNative.duckdb_jdbc_prepare(conn.connRef, sql.getBytes(UTF_8));
                 // Track prepared statement inside the parent connection
                 conn.preparedStatements.add(this);

--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -2226,6 +2226,35 @@ public class TestDuckDBJDBC {
         DriverManager.getConnection("jdbc:duckdb:;foo=bar;jdbc_ignore_unsupported_options=yes;", config).close();
     }
 
+    public static void test_issue_22042_pivot_autocommit_false() throws Exception {
+        // Dynamic PIVOT expands to CREATE TYPE + SELECT; inside a JDBC transaction the preprocessor can also inject
+        // leading/trailing SET statements. The driver must still prepare the SELECT and return a ResultSet.
+        try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
+            conn.setAutoCommit(false);
+            try (Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery("pivot values(1,2),(1,3) x(y,z) on x using first(y)")) {
+                int rows = 0;
+                boolean sawPivot2Col1 = false;
+                boolean sawPivot3Null = false;
+                while (rs.next()) {
+                    rows++;
+                    int c1 = rs.getInt(1);
+                    Object c2 = rs.getObject(2);
+                    if (c1 == 2 && c2 != null && ((Number) c2).intValue() == 1) {
+                        sawPivot2Col1 = true;
+                    }
+                    if (c1 == 3 && c2 == null) {
+                        sawPivot3Null = true;
+                    }
+                }
+                assertEquals(rows, 2);
+                assertTrue(sawPivot2Col1);
+                assertTrue(sawPivot3Null);
+            }
+            conn.rollback();
+        }
+    }
+
     public static void test_extension_excel() throws Exception {
         // Check whether the Excel extension can be installed and loaded automatically
         try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement();


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/22042

## Problem

With **JDBC 1.5.2+** and **`Connection.setAutoCommit(false)`**, executing a **dynamic PIVOT** (pivot values inferred from data, so DuckDB expands the SQL into several statements) via **`Statement.executeQuery`** failed immediately with:

`java.sql.SQLException: executeQuery() can only be used with queries that return a ResultSet`

The engine’s statement preprocessor can wrap multi-statement bodies in an active transaction with leading/trailing **`SET current_transaction_invalidation_policy`** statements. The JNI path executed all statements except the last with `Query`, then **`Prepare`’d only `statements.back()`**. When the syntactic last statement was that trailing **`SET`**, the prepared “query” did not return a **`QUERY_RESULT`**, so JDBC correctly rejected **`executeQuery`**. Starting a JDBC transaction **before** `duckdb_jdbc_prepare` also made that expansion more likely at prepare time.

## Solution

- In **`duckdb_jdbc_prepare`** and **`duckdb_jdbc_pending_query`**, locate the **last `SELECT_STATEMENT`** in the extracted statement list, run all **prefix** statements with `Query`, **`Prepare` / `PendingQuery`** that SELECT, and store **trailing** SQL text to run **after** each successful **`Execute`** (so repeated `execute()` on the same `PreparedStatement` still runs policy resets).
- In **`DuckDBPreparedStatement.prepare()`**, **do not** call **`startTransaction()`** before native prepare; transactions are still started in **`execute()`** when **`autoCommit`** is off.

## Changes

- `src/jni/duckdb_java.cpp` — `FindLastSelectStatementIndex`, `ExecuteTrailingQueries`; updated prepare / pending / execute paths.
- `src/jni/holders.hpp` — `StatementHolder::trailing_queries_after_execute`; `PendingHolder` trailing queries + `connection_for_trailing`.
- `src/main/java/org/duckdb/DuckDBPreparedStatement.java` — remove `startTransaction()` from `prepare()`.
- `src/test/java/org/duckdb/TestDuckDBJDBC.java` — `test_issue_22042_pivot_autocommit_false`.

## Testing

- `python3 scripts/format.py` (project formatter).
- Build: `make release` (or your usual CMake build), producing `build/release/duckdb_jdbc.jar` and `build/release/duckdb_jdbc_tests.jar`.
- Automated: `java -cp "build/release/duckdb_jdbc_tests.jar:build/release/duckdb_jdbc.jar" org.duckdb.TestDuckDBJDBC test_issue_22042_pivot_autocommit_false`
- Related sanity: `test_autocommit_off`, `test_multiple_statements_execution` via the same `TestDuckDBJDBC` runner.

### Manual verification

#### 1) Reproduce the original error (pre-fix behavior)

Use a **JDBC driver build from before this patch** (e.g. **1.5.2.0** as in the report, or a local build of `main` without these commits). Ensure **`duckdb_jdbc.jar`** and **`libduckdb_java`** (or the platform JNI library) are on the classpath / library path as usual for your environment.

1. Save as `F.java`:

```java
import java.sql.DriverManager;
import java.sql.SQLException;

public class F {
	public static void main(String... a) throws SQLException {
		try (var connection = DriverManager.getConnection("jdbc:duckdb:")) {
			connection.setAutoCommit(false);
			try (var stmt = connection.createStatement()) {
				var result = stmt.executeQuery(
					"pivot values(1,2),(1,3) x(y,z) on x using first(y)");
				while (result.next()) {
					System.out.println(result.getObject(1) + ", " + result.getObject(2));
				}
				result.close();
			}
		}
	}
}
```

2. Compile and run (adjust classpath to your pre-fix **`duckdb_jdbc.jar`**):

```bash
javac -cp duckdb_jdbc.jar F.java
java -cp ".:duckdb_jdbc.jar" F
```

**Expected (bug):** immediate failure with:

`java.sql.SQLException: executeQuery() can only be used with queries that return a ResultSet`

With **`setAutoCommit(true)`** (default), the same program typically **succeeds** and prints two rows (e.g. `2, 1` and `3, null`), which highlights the regression tied to **manual commit / active transaction** semantics.

#### 2) Confirm this patch works (post-fix)

1. Build the driver from this branch:

```bash
cd /path/to/duckdb-java
make release
```

2. Run the regression test:

```bash
java -cp "build/release/duckdb_jdbc_tests.jar:build/release/duckdb_jdbc.jar" \
  org.duckdb.TestDuckDBJDBC test_issue_22042_pivot_autocommit_false
```

**Expected:** `TestDuckDBJDBC#test_issue_22042_pivot_autocommit_false success` and `OK`.

3. Re-run the **`F.java`** sample above, but put **`build/release/duckdb_jdbc.jar`** on the classpath (and ensure the JNI library from the same build is loaded, e.g. via `-Djava.library.path=build/release` if required by your setup).

**Expected:** no exception; two rows printed (values equivalent to **`2, 1`** and **`3, null`**, order may vary).
