### PR TITLE
Implement getUDTs method

### DIFF
--- a/src/main/java/org/duckdb/DuckDBDatabaseMetaData.java
+++ b/src/main/java/org/duckdb/DuckDBDatabaseMetaData.java
@@ -1289,8 +1289,8 @@ public class DuckDBDatabaseMetaData implements DatabaseMetaData {
             "CASE WHEN logical_type IN ('STRUCT', 'UNION') THEN " + Types.STRUCT + " ELSE " + Types.DISTINCT + " END";
         String baseTypeExpr = "CASE WHEN logical_type IN ('STRUCT', 'UNION') THEN NULL::SMALLINT "
                               + "WHEN logical_type = 'ENUM' THEN " + Types.VARCHAR + "::SMALLINT "
-                              + "ELSE CAST(CASE logical_type " + dataMap + " ELSE " + Types.OTHER
-                              + " END AS SMALLINT) END";
+                              + "ELSE CAST(CASE logical_type " + dataMap + " ELSE " + Types.OTHER +
+                              " END AS SMALLINT) END";
 
         StringBuilder sb = new StringBuilder(QUERY_SB_DEFAULT_CAPACITY);
         sb.append("SELECT").append(lineSeparator());

--- a/src/main/java/org/duckdb/DuckDBDatabaseMetaData.java
+++ b/src/main/java/org/duckdb/DuckDBDatabaseMetaData.java
@@ -1285,7 +1285,61 @@ public class DuckDBDatabaseMetaData implements DatabaseMetaData {
     @Override
     public ResultSet getUDTs(String catalog, String schemaPattern, String typeNamePattern, int[] types)
         throws SQLException {
-        throw new SQLFeatureNotSupportedException("getUDTs");
+        String udtDataTypeExpr =
+            "CASE WHEN logical_type IN ('STRUCT', 'UNION') THEN " + Types.STRUCT + " ELSE " + Types.DISTINCT + " END";
+        String baseTypeExpr = "CASE WHEN logical_type IN ('STRUCT', 'UNION') THEN NULL::SMALLINT "
+                              + "WHEN logical_type = 'ENUM' THEN " + Types.VARCHAR + "::SMALLINT "
+                              + "ELSE CAST(CASE logical_type " + dataMap + " ELSE " + Types.OTHER
+                              + " END AS SMALLINT) END";
+
+        StringBuilder sb = new StringBuilder(QUERY_SB_DEFAULT_CAPACITY);
+        sb.append("SELECT").append(lineSeparator());
+        sb.append("database_name AS 'TYPE_CAT'").append(TRAILING_COMMA).append(lineSeparator());
+        sb.append("schema_name AS 'TYPE_SCHEM'").append(TRAILING_COMMA).append(lineSeparator());
+        sb.append("type_name AS 'TYPE_NAME'").append(TRAILING_COMMA).append(lineSeparator());
+        sb.append("NULL::VARCHAR AS 'CLASS_NAME'").append(TRAILING_COMMA).append(lineSeparator());
+        sb.append(udtDataTypeExpr).append(" AS 'DATA_TYPE'").append(TRAILING_COMMA).append(lineSeparator());
+        sb.append("comment AS 'REMARKS'").append(TRAILING_COMMA).append(lineSeparator());
+        sb.append(baseTypeExpr).append(" AS 'BASE_TYPE'").append(lineSeparator());
+        sb.append("FROM duckdb_types()").append(lineSeparator());
+        sb.append("WHERE internal = FALSE").append(lineSeparator());
+        boolean hasCatalogParam = appendEqualsQual(sb, "database_name", catalog);
+        boolean hasSchemaParam = appendLikeQual(sb, "schema_name", schemaPattern);
+        sb.append("AND type_name LIKE ? ESCAPE '\\'").append(lineSeparator());
+
+        if (types != null && types.length > 0) {
+            sb.append("AND (").append(udtDataTypeExpr).append(") IN (");
+            for (int i = 0; i < types.length; i++) {
+                if (i > 0) {
+                    sb.append(',');
+                }
+                sb.append('?');
+            }
+            sb.append(')').append(lineSeparator());
+        }
+
+        sb.append("ORDER BY").append(lineSeparator());
+        sb.append("\"DATA_TYPE\"").append(TRAILING_COMMA).append(lineSeparator());
+        sb.append("\"TYPE_CAT\"").append(TRAILING_COMMA).append(lineSeparator());
+        sb.append("\"TYPE_SCHEM\"").append(TRAILING_COMMA).append(lineSeparator());
+        sb.append("\"TYPE_NAME\"").append(lineSeparator());
+
+        PreparedStatement ps = conn.prepareStatement(sb.toString());
+        int paramIdx = 1;
+        if (hasCatalogParam) {
+            ps.setString(paramIdx++, catalog);
+        }
+        if (hasSchemaParam) {
+            ps.setString(paramIdx++, schemaPattern);
+        }
+        ps.setString(paramIdx++, nullPatternToWildcard(typeNamePattern));
+        if (types != null) {
+            for (int type : types) {
+                ps.setInt(paramIdx++, type);
+            }
+        }
+        ps.closeOnCompletion();
+        return ps.executeQuery();
     }
 
     @Override

--- a/src/test/java/org/duckdb/TestMetadata.java
+++ b/src/test/java/org/duckdb/TestMetadata.java
@@ -1123,8 +1123,7 @@ public class TestMetadata {
                     assertEquals(rs.getInt("DATA_TYPE"), Types.DISTINCT);
                 }
                 assertTrue(names.contains("mood"));
-                assertTrue(names.contains("x_index"));
-                assertEquals(names.size(), 2);
+                assertEquals(names.size(), 1);
             }
 
             try (ResultSet rs = dbMetaData.getUDTs(null, null, "%", new int[] {Types.STRUCT})) {

--- a/src/test/java/org/duckdb/TestMetadata.java
+++ b/src/test/java/org/duckdb/TestMetadata.java
@@ -1074,4 +1074,69 @@ public class TestMetadata {
             }
         }
     }
+
+    public static void test_metadata_get_udts() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TYPE mood AS ENUM ('sad','ok','happy')");
+            stmt.execute("CREATE TYPE many_things AS STRUCT(name VARCHAR, age INTEGER)");
+            stmt.execute("CREATE TYPE one_thing AS UNION(a INTEGER, b VARCHAR)");
+            stmt.execute("CREATE TYPE x_index AS INTEGER");
+
+            DatabaseMetaData dbMetaData = conn.getMetaData();
+            Map<String, Integer> dataTypes = new HashMap<>();
+            Map<String, Integer> baseTypes = new HashMap<>();
+            try (ResultSet rs = dbMetaData.getUDTs(null, null, "%", null)) {
+                ResultSetMetaData rsMetaData = rs.getMetaData();
+                assertEquals(rsMetaData.getColumnName(1), "TYPE_CAT");
+                assertEquals(rsMetaData.getColumnName(2), "TYPE_SCHEM");
+                assertEquals(rsMetaData.getColumnName(3), "TYPE_NAME");
+                assertEquals(rsMetaData.getColumnName(4), "CLASS_NAME");
+                assertEquals(rsMetaData.getColumnName(5), "DATA_TYPE");
+                assertEquals(rsMetaData.getColumnName(6), "REMARKS");
+                assertEquals(rsMetaData.getColumnName(7), "BASE_TYPE");
+
+                while (rs.next()) {
+                    dataTypes.put(rs.getString("TYPE_NAME"), rs.getInt("DATA_TYPE"));
+                    int baseType = rs.getInt("BASE_TYPE");
+                    if (rs.wasNull()) {
+                        baseTypes.put(rs.getString("TYPE_NAME"), null);
+                    } else {
+                        baseTypes.put(rs.getString("TYPE_NAME"), baseType);
+                    }
+                }
+            }
+
+            assertEquals(dataTypes.get("mood"), Types.DISTINCT);
+            assertEquals(dataTypes.get("many_things"), Types.STRUCT);
+            assertEquals(dataTypes.get("one_thing"), Types.STRUCT);
+            assertEquals(dataTypes.get("x_index"), Types.DISTINCT);
+
+            assertEquals(baseTypes.get("mood"), Types.VARCHAR);
+            assertNull(baseTypes.get("many_things"));
+            assertNull(baseTypes.get("one_thing"));
+            assertEquals(baseTypes.get("x_index"), Types.INTEGER);
+
+            try (ResultSet rs = dbMetaData.getUDTs(null, null, "m%", new int[] {Types.DISTINCT})) {
+                Set<String> names = new HashSet<>();
+                while (rs.next()) {
+                    names.add(rs.getString("TYPE_NAME"));
+                    assertEquals(rs.getInt("DATA_TYPE"), Types.DISTINCT);
+                }
+                assertTrue(names.contains("mood"));
+                assertTrue(names.contains("x_index"));
+                assertEquals(names.size(), 2);
+            }
+
+            try (ResultSet rs = dbMetaData.getUDTs(null, null, "%", new int[] {Types.STRUCT})) {
+                Set<String> names = new HashSet<>();
+                while (rs.next()) {
+                    names.add(rs.getString("TYPE_NAME"));
+                    assertEquals(rs.getInt("DATA_TYPE"), Types.STRUCT);
+                }
+                assertTrue(names.contains("many_things"));
+                assertTrue(names.contains("one_thing"));
+                assertEquals(names.size(), 2);
+            }
+        }
+    }
 }


### PR DESCRIPTION
This PR supersedes PR #645.

I ran into the fact that the getUDTs method isn't implemented when writing a [Slick extension for DuckDB](https://github.com/Algebrazebra/slick-duckdb).

This implementation uses a query against `duckdb_types()` and maps the DuckDB result columns to the column names required by the JDBC interface definition:
- `database_name -> TYPE_CAT`
- `schema_name -> TYPE_SCHEM`
- `type_name -> TYPE_NAME`
- `comment -> REMARKS`
- `CLASS_NAME` returned as `NULL`

The types themselves are mapped to the base type when a scalar base type is available, but `STRUCT` and `UNION` don't have one so it maps to `NULL`.
