### PR TITLE
Update vendored DuckDB sources to 01cf2e8119

### DIFF
--- a/src/duckdb/src/function/table/version/pragma_version.cpp
+++ b/src/duckdb/src/function/table/version/pragma_version.cpp
@@ -1,5 +1,5 @@
 #ifndef DUCKDB_PATCH_VERSION
-#define DUCKDB_PATCH_VERSION "5-dev81"
+#define DUCKDB_PATCH_VERSION "5-dev83"
 #endif
 #ifndef DUCKDB_MINOR_VERSION
 #define DUCKDB_MINOR_VERSION 4
@@ -8,10 +8,10 @@
 #define DUCKDB_MAJOR_VERSION 1
 #endif
 #ifndef DUCKDB_VERSION
-#define DUCKDB_VERSION "v1.4.5-dev81"
+#define DUCKDB_VERSION "v1.4.5-dev83"
 #endif
 #ifndef DUCKDB_SOURCE_ID
-#define DUCKDB_SOURCE_ID "e4c85765ee"
+#define DUCKDB_SOURCE_ID "01cf2e8119"
 #endif
 #include "duckdb/function/table/system_functions.hpp"
 #include "duckdb/main/database.hpp"


### PR DESCRIPTION
Changes:
 - [duckdb/duckdb#01cf2e8119](https://github.com/duckdb/duckdb/commit/01cf2e8119) imported at 2026-06-05 06:31:52
