### PR TITLE
Re-enable jemalloc on Linux (main)

### DIFF
--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -40,11 +40,17 @@ endif()
 set(DUCKDB_INCLUDE_DIRS
   ${INCLUDES})
 
+set(JEMALLOC_INCLUDE_DIRS
+  ${JEMALLOC_INCLUDES})
+
 set(DUCKDB_DEFINITIONS
   ${DEFINES})
 
 set(DUCKDB_SRC_FILES 
   ${SOURCES})
+
+set(JEMALLOC_SRC_FILES 
+  ${JEMALLOC_SOURCES})
 
 
 # a few OS-specific variables
@@ -96,7 +102,10 @@ add_jar(duckdb_jdbc_tests ${JAVA_TEST_FILES} INCLUDE_JARS duckdb_jdbc_nolib)
 # main shared lib compilation
 
 if(MSVC OR ZOS)
+  list(APPEND DUCKDB_INCLUDE_DIRS src/stubs)
   list(APPEND DUCKDB_SRC_FILES duckdb_java.def)
+else()
+  list(APPEND DUCKDB_SRC_FILES ${JEMALLOC_SRC_FILES})
 endif()
 
 add_library(duckdb_java SHARED
@@ -125,6 +134,11 @@ target_include_directories(duckdb_java PRIVATE
   ${JAVA_INCLUDE_PATH}
   ${JAVA_INCLUDE_PATH2}
   ${DUCKDB_INCLUDE_DIRS})
+
+if (NOT MSVC AND NOT ZOS)
+  target_include_directories(duckdb_java PRIVATE
+    ${JEMALLOC_INCLUDE_DIRS})
+endif()
 
 target_link_libraries(duckdb_java PRIVATE
   duckdb-native
@@ -155,7 +169,7 @@ target_compile_definitions(duckdb_java PRIVATE
 
 if(NOT MSVC AND NOT ZOS)
   target_compile_definitions(duckdb_java PRIVATE
-    -DDUCKDB_EXTENSION_JEMALLOC_LINKED)
+    -DDUCKDB_ENABLE_JEMALLOC)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/vendor.py
+++ b/vendor.py
@@ -5,6 +5,9 @@ import pickle
 import platform
 import argparse
 
+def sanitize_path(x):
+    return x.replace('\\', '/')
+
 parser = argparse.ArgumentParser(description='Inlines DuckDB Sources')
 
 parser.add_argument('--duckdb', action='store',
@@ -12,8 +15,7 @@ parser.add_argument('--duckdb', action='store',
 
 args = parser.parse_args()
 
-# list of extensions to bundle, we include jemalloc here to have its
-# files copied along with all other sources
+# list of extensions to bundle
 extensions = ['core_functions', 'parquet', 'icu', 'json']
 
 # path to target
@@ -31,16 +33,28 @@ defines = ['DUCKDB_EXTENSION_{}_LINKED'.format(ext.upper()) for ext in extension
 
 # fresh build - copy over all of the files
 (source_list, include_list, original_sources) = package_build.build_package(target_dir, extensions, False)
-
-source_list = [os.path.relpath(x, basedir) if os.path.isabs(x) else os.path.join('src', x)
-    for x in source_list]
-include_list = [os.path.join('src', 'duckdb', x) for x in include_list]
-
-def sanitize_path(x):
-    return x.replace('\\', '/')
-
 source_list = [sanitize_path(x) for x in source_list]
 include_list = [sanitize_path(x) for x in include_list]
+
+# process jemalloc separately with its own CMake vars
+jemalloc_source_list = [x for x in source_list if x.startswith("duckdb/third_party/jemalloc/")]
+jemalloc_include_list = [x for x in include_list if x.startswith("third_party/jemalloc/")]
+
+# clean up paths
+source_list = [os.path.relpath(x, basedir) if os.path.isabs(x) else os.path.join('src', x)
+    for x in source_list if x not in jemalloc_source_list]
+source_list = [x.replace("/./", "/") for x in source_list]
+jemalloc_source_list = [os.path.relpath(x, basedir) if os.path.isabs(x) else os.path.join('src', x)
+    for x in jemalloc_source_list]
+jemalloc_source_list = [x for x in jemalloc_source_list if not x.endswith("jemalloc_cpp.cpp")]
+include_list = [os.path.join('src', 'duckdb', x) for x in include_list if x not in jemalloc_include_list]
+jemalloc_include_list = [os.path.join('src', 'duckdb', x) for x in jemalloc_include_list]
+
+# sort paths
+source_list.sort()
+jemalloc_source_list.sort()
+include_list.sort()
+jemalloc_include_list.sort()
 
 os.chdir(basedir)
 
@@ -51,7 +65,9 @@ def replace_entries(cmake, replacement_map):
     cmake.replace()
 
 cmake = cmake.replace('${SOURCES}', '\n  '.join(source_list))
+cmake = cmake.replace('${JEMALLOC_SOURCES}', '\n  '.join(jemalloc_source_list))
 cmake = cmake.replace('${INCLUDES}', '\n  '.join(include_list))
+cmake = cmake.replace('${JEMALLOC_INCLUDES}', '\n  '.join(jemalloc_include_list))
 cmake = cmake.replace('${DEFINES}', '\n  '.join(['-D'+x for x in defines]))
 
 with open('CMakeLists.txt', 'w+') as f:


### PR DESCRIPTION
This is a forward-port of the PR #686 to the `main` branch.

This PR enables back `jemalloc` allocator for Linux builds applying the necessary changes to its packaging after duckdb/duckdb#22558.