### PR TITLE
Update vendored DuckDB sources to f31be57c18

### DIFF
--- a/src/duckdb/src/function/table/version/pragma_version.cpp
+++ b/src/duckdb/src/function/table/version/pragma_version.cpp
@@ -1,5 +1,5 @@
 #ifndef DUCKDB_PATCH_VERSION
-#define DUCKDB_PATCH_VERSION "5-dev107"
+#define DUCKDB_PATCH_VERSION "5"
 #endif
 #ifndef DUCKDB_MINOR_VERSION
 #define DUCKDB_MINOR_VERSION 4
@@ -8,7 +8,7 @@
 #define DUCKDB_MAJOR_VERSION 1
 #endif
 #ifndef DUCKDB_VERSION
-#define DUCKDB_VERSION "v1.4.5-dev107"
+#define DUCKDB_VERSION "v1.4.5"
 #endif
 #ifndef DUCKDB_SOURCE_ID
 #define DUCKDB_SOURCE_ID "f31be57c18"


### PR DESCRIPTION
Changes:
 - [duckdb/duckdb#f31be57c18](https://github.com/duckdb/duckdb/commit/f31be57c18) imported at 2026-06-17 11:27:52
