### PR TITLE
Promptly delete local JNI references (1.5)

### DIFF
--- a/src/jni/config.cpp
+++ b/src/jni/config.cpp
@@ -68,6 +68,7 @@ static duckdb::Value jobj_to_value(JNIEnv *env, const std::string &key, jobject 
 			duckdb::Value val(std::move(sval));
 			vec.push_back(std::move(val));
 		}
+		check_java_exception_and_rethrow(env);
 		return duckdb::Value::LIST(duckdb::LogicalType::VARCHAR, std::move(vec));
 
 	} else {
@@ -120,6 +121,7 @@ std::unique_ptr<duckdb::DBConfig> create_db_config(JNIEnv *env, jboolean read_on
 			                               error.RawMessage());
 		}
 	}
+	check_java_exception_and_rethrow(env);
 
 	return config;
 }

--- a/src/jni/duckdb_java.cpp
+++ b/src/jni/duckdb_java.cpp
@@ -312,6 +312,9 @@ jobject _duckdb_jdbc_execute(JNIEnv *env, jclass, jobject stmt_ref_buf, jobjectA
 	    stmt_ref->stmt->context->TryGetCurrentSetting("jdbc_stream_results", result) ? result.GetValue<bool>() : false;
 	auto res_ref = make_uniq<ResultHolder>();
 	res_ref->res = execute_prepared_statement(env, stmt_ref_buf, params, stream_results);
+	if (res_ref->res == nullptr) {
+		return nullptr;
+	}
 	return env->NewDirectByteBuffer(res_ref.release(), 0);
 }
 
@@ -389,15 +392,19 @@ static jobject build_meta(JNIEnv *env, size_t column_count, size_t n_param, cons
 			col_name = types[col_idx].ToString();
 		}
 
-		env->SetObjectArrayElement(name_array, col_idx,
-		                           decode_charbuffer_to_jstring(env, names[col_idx].c_str(), names[col_idx].length()));
-		env->SetObjectArrayElement(type_array, col_idx, env->NewStringUTF(col_name.c_str()));
-		env->SetObjectArrayElement(type_detail_array, col_idx,
-		                           env->NewStringUTF(type_to_jduckdb_type(types[col_idx]).c_str()));
+		jstring jname = decode_charbuffer_to_jstring(env, names[col_idx].c_str(), names[col_idx].length());
+		env->SetObjectArrayElement(name_array, col_idx, jname);
+		env->DeleteLocalRef(jname);
+		jstring jcolname = env->NewStringUTF(col_name.c_str());
+		env->SetObjectArrayElement(type_array, col_idx, jcolname);
+		env->DeleteLocalRef(jcolname);
+		jstring jtype = env->NewStringUTF(type_to_jduckdb_type(types[col_idx]).c_str());
+		env->SetObjectArrayElement(type_detail_array, col_idx, jtype);
+		env->DeleteLocalRef(jtype);
 	}
 
-	auto param_type_array = env->NewObjectArray(n_param, J_String, nullptr);
-	auto param_type_detail_array = env->NewObjectArray(n_param, J_String, nullptr);
+	jobjectArray param_type_array = env->NewObjectArray(n_param, J_String, nullptr);
+	jobjectArray param_type_detail_array = env->NewObjectArray(n_param, J_String, nullptr);
 
 	for (idx_t param_idx = 0; param_idx < n_param; param_idx++) {
 		std::string param_name;
@@ -407,15 +414,25 @@ static jobject build_meta(JNIEnv *env, size_t column_count, size_t n_param, cons
 			param_name = param_types[param_idx].ToString();
 		}
 
-		env->SetObjectArrayElement(param_type_array, param_idx, env->NewStringUTF(param_name.c_str()));
-		env->SetObjectArrayElement(param_type_detail_array, param_idx,
-		                           env->NewStringUTF(type_to_jduckdb_type(param_types[param_idx]).c_str()));
+		jstring jname = env->NewStringUTF(param_name.c_str());
+		env->SetObjectArrayElement(param_type_array, param_idx, jname);
+		env->DeleteLocalRef(jname);
+		jstring jdetail = env->NewStringUTF(type_to_jduckdb_type(param_types[param_idx]).c_str());
+		env->SetObjectArrayElement(param_type_detail_array, param_idx, jdetail);
+		env->DeleteLocalRef(jdetail);
 	}
 
-	auto return_type = env->NewStringUTF(StatementReturnTypeToString(properties.return_type).c_str());
+	jstring return_type = env->NewStringUTF(StatementReturnTypeToString(properties.return_type).c_str());
 
-	return env->NewObject(J_DuckResultSetMeta, J_DuckResultSetMeta_init, n_param, column_count, name_array, type_array,
-	                      type_detail_array, return_type, param_type_array, param_type_detail_array);
+	jobject res = env->NewObject(J_DuckResultSetMeta, J_DuckResultSetMeta_init, n_param, column_count, name_array,
+	                             type_array, type_detail_array, return_type, param_type_array, param_type_detail_array);
+	env->DeleteLocalRef(return_type);
+	env->DeleteLocalRef(param_type_detail_array);
+	env->DeleteLocalRef(param_type_array);
+	env->DeleteLocalRef(type_detail_array);
+	env->DeleteLocalRef(type_array);
+	env->DeleteLocalRef(name_array);
+	return res;
 }
 
 jobject _duckdb_jdbc_query_result_meta(JNIEnv *env, jclass, jobject res_ref_buf) {
@@ -434,7 +451,7 @@ jobject _duckdb_jdbc_query_result_meta(JNIEnv *env, jclass, jobject res_ref_buf)
 
 jobject _duckdb_jdbc_prepared_statement_meta(JNIEnv *env, jclass, jobject stmt_ref_buf) {
 
-	auto stmt_ref = (StatementHolder *)env->GetDirectBufferAddress(stmt_ref_buf);
+	auto stmt_ref = reinterpret_cast<StatementHolder *>(env->GetDirectBufferAddress(stmt_ref_buf));
 	if (!stmt_ref || !stmt_ref->stmt || stmt_ref->stmt->HasError()) {
 		throw InvalidInputException("Invalid statement");
 	}
@@ -456,7 +473,7 @@ jobject _duckdb_jdbc_prepared_statement_meta(JNIEnv *env, jclass, jobject stmt_r
 jobject ProcessVector(JNIEnv *env, Connection *conn_ref, Vector &vec, idx_t row_count);
 
 jobjectArray _duckdb_jdbc_fetch(JNIEnv *env, jclass, jobject res_ref_buf, jobject conn_ref_buf) {
-	auto res_ref = (ResultHolder *)env->GetDirectBufferAddress(res_ref_buf);
+	auto res_ref = reinterpret_cast<ResultHolder *>(env->GetDirectBufferAddress(res_ref_buf));
 	if (!res_ref || !res_ref->res || res_ref->res->HasError()) {
 		throw InvalidInputException("Invalid result set");
 	}
@@ -471,14 +488,16 @@ jobjectArray _duckdb_jdbc_fetch(JNIEnv *env, jclass, jobject res_ref_buf, jobjec
 		res_ref->chunk = make_uniq<DataChunk>();
 	}
 	auto row_count = res_ref->chunk->size();
-	auto vec_array = (jobjectArray)env->NewObjectArray(res_ref->chunk->ColumnCount(), J_DuckVector, nullptr);
+	jobjectArray vec_array =
+	    reinterpret_cast<jobjectArray>(env->NewObjectArray(res_ref->chunk->ColumnCount(), J_DuckVector, nullptr));
 
 	for (idx_t col_idx = 0; col_idx < res_ref->chunk->ColumnCount(); col_idx++) {
 		auto &vec = res_ref->chunk->data[col_idx];
 
-		auto jvec = ProcessVector(env, conn_ref, vec, row_count);
+		jobject jvec = ProcessVector(env, conn_ref, vec, row_count);
 
 		env->SetObjectArrayElement(vec_array, col_idx, jvec);
+		env->DeleteLocalRef(jvec);
 	}
 
 	return vec_array;
@@ -522,16 +541,16 @@ jobject ProcessVector(JNIEnv *env, Connection *conn_ref, Vector &vec, idx_t row_
 	if (vec.GetVectorType() != VectorType::FLAT_VECTOR) {
 		vec.Flatten(row_count);
 	}
-	auto type_str = env->NewStringUTF(type_to_jduckdb_type(vec.GetType()).c_str());
+	jstring type_str = env->NewStringUTF(type_to_jduckdb_type(vec.GetType()).c_str());
 	// construct nullmask
-	auto null_array = env->NewBooleanArray(row_count);
+	jbooleanArray null_array = env->NewBooleanArray(row_count);
 	jboolean *null_unique_array = env->GetBooleanArrayElements(null_array, nullptr);
 	for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
 		null_unique_array[row_idx] = FlatVector::IsNull(vec, row_idx);
 	}
 	env->ReleaseBooleanArrayElements(null_array, null_unique_array, 0);
 
-	auto jvec = env->NewObject(J_DuckVector, J_DuckVector_init, type_str, (int)row_count, null_array);
+	jobject jvec = env->NewObject(J_DuckVector, J_DuckVector_init, type_str, static_cast<int>(row_count), null_array);
 
 	jobject constlen_data = nullptr;
 	jobjectArray varlen_data = nullptr;
@@ -622,9 +641,10 @@ jobject ProcessVector(JNIEnv *env, Connection *conn_ref, Vector &vec, idx_t row_
 			if (FlatVector::IsNull(vec, row_idx)) {
 				continue;
 			}
-			auto d_str = vec.GetValue(row_idx).ToString();
-			jstring j_str = env->NewStringUTF(d_str.c_str());
-			env->SetObjectArrayElement(varlen_data, row_idx, j_str);
+			auto dstr = vec.GetValue(row_idx).ToString();
+			jstring jstr = env->NewStringUTF(dstr.c_str());
+			env->SetObjectArrayElement(varlen_data, row_idx, jstr);
+			env->DeleteLocalRef(jstr);
 		}
 		break;
 	case LogicalTypeId::UNION:
@@ -636,16 +656,22 @@ jobject ProcessVector(JNIEnv *env, Connection *conn_ref, Vector &vec, idx_t row_
 		auto names = env->NewObjectArray(entries.size(), J_String, nullptr);
 
 		for (idx_t entry_i = 0; entry_i < entries.size(); entry_i++) {
-			auto j_vec = ProcessVector(env, conn_ref, *entries[entry_i], row_count);
+			jobject j_vec = ProcessVector(env, conn_ref, *entries[entry_i], row_count);
 			env->SetObjectArrayElement(columns, entry_i, j_vec);
-			env->SetObjectArrayElement(names, entry_i,
-			                           env->NewStringUTF(StructType::GetChildName(vec.GetType(), entry_i).c_str()));
+			env->DeleteLocalRef(j_vec);
+			jstring jstr = env->NewStringUTF(StructType::GetChildName(vec.GetType(), entry_i).c_str());
+			env->SetObjectArrayElement(names, entry_i, jstr);
+			env->DeleteLocalRef(jstr);
 		}
 		for (idx_t row_idx = 0; row_idx < row_count; row_idx++) {
-			env->SetObjectArrayElement(varlen_data, row_idx,
-			                           env->NewObject(J_DuckStruct, J_DuckStruct_init, names, columns, row_idx,
-			                                          env->NewStringUTF(vec.GetType().ToString().c_str())));
+			jstring jstr = env->NewStringUTF(vec.GetType().ToString().c_str());
+			jobject jstruct = env->NewObject(J_DuckStruct, J_DuckStruct_init, names, columns, row_idx, jstr);
+			env->SetObjectArrayElement(varlen_data, row_idx, jstruct);
+			env->DeleteLocalRef(jstruct);
+			env->DeleteLocalRef(jstr);
 		}
+		env->DeleteLocalRef(names);
+		env->DeleteLocalRef(columns);
 
 		break;
 	}
@@ -665,6 +691,7 @@ jobject ProcessVector(JNIEnv *env, Connection *conn_ref, Vector &vec, idx_t row_
 			env->ReleaseByteArrayElements(j_arr, j_arr_el, 0);
 
 			env->SetObjectArrayElement(varlen_data, row_idx, j_arr);
+			env->DeleteLocalRef(j_arr);
 		}
 		break;
 	case LogicalTypeId::UUID:
@@ -674,7 +701,7 @@ jobject ProcessVector(JNIEnv *env, Connection *conn_ref, Vector &vec, idx_t row_
 		varlen_data = env->NewObjectArray(row_count, J_DuckArray, nullptr);
 		auto &array_vector = ArrayVector::GetEntry(vec);
 		auto total_size = row_count * ArrayType::GetSize(vec.GetType());
-		auto j_vec = ProcessVector(env, conn_ref, array_vector, total_size);
+		jobject j_vec = ProcessVector(env, conn_ref, array_vector, total_size);
 
 		auto limit = ArrayType::GetSize(vec.GetType());
 
@@ -688,7 +715,9 @@ jobject ProcessVector(JNIEnv *env, Connection *conn_ref, Vector &vec, idx_t row_
 			auto j_obj = env->NewObject(J_DuckArray, J_DuckArray_init, j_vec, offset, limit);
 
 			env->SetObjectArrayElement(varlen_data, row_idx, j_obj);
+			env->DeleteLocalRef(j_obj);
 		}
+		env->DeleteLocalRef(j_vec);
 		break;
 	}
 	case LogicalTypeId::MAP:
@@ -712,7 +741,9 @@ jobject ProcessVector(JNIEnv *env, Connection *conn_ref, Vector &vec, idx_t row_
 			auto j_obj = env->NewObject(J_DuckArray, J_DuckArray_init, j_vec, offset, limit);
 
 			env->SetObjectArrayElement(varlen_data, row_idx, j_obj);
+			env->DeleteLocalRef(j_obj);
 		}
+		env->DeleteLocalRef(j_vec);
 		break;
 	}
 	case LogicalTypeId::VARIANT: {
@@ -728,7 +759,9 @@ jobject ProcessVector(JNIEnv *env, Connection *conn_ref, Vector &vec, idx_t row_
 			Vector variant_vec(variant_val);
 			jobject variant_j_vec = ProcessVector(env, conn_ref, variant_vec, 1);
 			env->CallVoidMethod(variant_j_vec, J_DuckVector_retainConstlenData);
+			check_java_exception_and_rethrow(env);
 			env->SetObjectArrayElement(varlen_data, row_idx, variant_j_vec);
+			env->DeleteLocalRef(variant_j_vec);
 		}
 		break;
 	}
@@ -750,12 +783,22 @@ jobject ProcessVector(JNIEnv *env, Connection *conn_ref, Vector &vec, idx_t row_
 			auto d_str = ((string_t *)FlatVector::GetData(vec))[row_idx];
 			auto j_str = decode_charbuffer_to_jstring(env, d_str.GetData(), d_str.GetSize());
 			env->SetObjectArrayElement(varlen_data, row_idx, j_str);
+			env->DeleteLocalRef(j_str);
 		}
 		break;
 	}
 
 	env->SetObjectField(jvec, J_DuckVector_constlen, constlen_data);
+	if (constlen_data != nullptr) {
+		env->DeleteLocalRef(constlen_data);
+	}
 	env->SetObjectField(jvec, J_DuckVector_varlen, varlen_data);
+	if (varlen_data != nullptr) {
+		env->DeleteLocalRef(varlen_data);
+	}
+
+	env->DeleteLocalRef(null_array);
+	env->DeleteLocalRef(type_str);
 
 	return jvec;
 }

--- a/src/jni/types.cpp
+++ b/src/jni/types.cpp
@@ -49,7 +49,9 @@ std::string type_to_jduckdb_type(duckdb::LogicalType logical_type) {
 
 duckdb::Value create_value_from_bigdecimal(JNIEnv *env, jobject decimal) {
 	jint precision = env->CallIntMethod(decimal, J_BigDecimal_precision);
+	check_java_exception_and_rethrow(env);
 	jint scale = env->CallIntMethod(decimal, J_BigDecimal_scale);
+	check_java_exception_and_rethrow(env);
 
 	// Java BigDecimal type can have scale that exceeds the precision
 	// Which our DECIMAL type does not support (assert(width >= scale))
@@ -66,10 +68,13 @@ duckdb::Value create_value_from_bigdecimal(JNIEnv *env, jobject decimal) {
 
 	if (precision <= 18) { // normal sizes -> avoid string processing
 		jobject no_point_dec = env->CallObjectMethod(decimal, J_BigDecimal_scaleByPowTen, scale);
+		check_java_exception_and_rethrow(env);
 		jlong result = env->CallLongMethod(no_point_dec, J_BigDecimal_longValue);
+		check_java_exception_and_rethrow(env);
 		val = duckdb::Value::DECIMAL((int64_t)result, (uint8_t)precision, (uint8_t)scale);
 	} else if (precision <= 38) { // larger than int64 -> get string and cast
 		jobject str_val = env->CallObjectMethod(decimal, J_BigDecimal_toPlainString);
+		check_java_exception_and_rethrow(env);
 		auto *str_char = env->GetStringUTFChars((jstring)str_val, 0);
 		val = duckdb::Value(str_char);
 		val = val.DefaultCastAs(duckdb::LogicalType::DECIMAL(precision, scale));
@@ -88,45 +93,59 @@ static duckdb::Value create_value_from_hugeint(JNIEnv *env, jobject hugeint) {
 
 static duckdb::Value create_value_from_uuid(JNIEnv *env, jobject param) {
 	jlong most_significant = env->CallLongMethod(param, J_UUID_getMostSignificantBits);
+	check_java_exception_and_rethrow(env);
 	// Account for the following logic in UUID::FromString:
 	// Flip the first bit to make `order by uuid` same as `order by uuid::varchar`
 	most_significant ^= (std::numeric_limits<int64_t>::min)();
 	jlong least_significant = env->CallLongMethod(param, J_UUID_getLeastSignificantBits);
+	check_java_exception_and_rethrow(env);
 	duckdb::hugeint_t hi = duckdb::hugeint_t(most_significant, least_significant);
 	return duckdb::Value::UUID(std::move(hi));
 }
 
 static duckdb::Value create_value_from_map(JNIEnv *env, jobject param, duckdb::ClientContext &context) {
-	auto typeName = jstring_to_string(env, (jstring)env->CallObjectMethod(param, J_DuckMap_getSQLTypeName));
+	jstring jstr = reinterpret_cast<jstring>(env->CallObjectMethod(param, J_DuckMap_getSQLTypeName));
+	check_java_exception_and_rethrow(env);
+	auto typeName = jstring_to_string(env, jstr);
 
 	duckdb::LogicalType type;
 	context.RunFunctionInTransaction([&]() { type = duckdb::TransformStringToLogicalType(typeName, context); });
 
 	auto entrySet = env->CallObjectMethod(param, J_Map_entrySet);
+	check_java_exception_and_rethrow(env);
 	auto iterator = env->CallObjectMethod(entrySet, J_Set_iterator);
+	check_java_exception_and_rethrow(env);
 	duckdb::vector<duckdb::Value> entries;
 	while (env->CallBooleanMethod(iterator, J_Iterator_hasNext)) {
+		check_java_exception_and_rethrow(env);
 		auto entry = env->CallObjectMethod(iterator, J_Iterator_next);
+		check_java_exception_and_rethrow(env);
 
 		auto key = env->CallObjectMethod(entry, J_Entry_getKey);
+		check_java_exception_and_rethrow(env);
 		auto value = env->CallObjectMethod(entry, J_Entry_getValue);
+		check_java_exception_and_rethrow(env);
 		D_ASSERT(key);
 		D_ASSERT(value);
 
 		entries.push_back(duckdb::Value::STRUCT(
 		    {{"key", to_duckdb_value(env, key, context)}, {"value", to_duckdb_value(env, value, context)}}));
 	}
+	check_java_exception_and_rethrow(env);
 
 	return duckdb::Value::MAP(duckdb::ListType::GetChildType(type), entries);
 }
 
 static duckdb::Value create_value_from_struct(JNIEnv *env, jobject param, duckdb::ClientContext &context) {
-	auto typeName = jstring_to_string(env, (jstring)env->CallObjectMethod(param, J_Struct_getSQLTypeName));
+	jstring jstr = reinterpret_cast<jstring>(env->CallObjectMethod(param, J_Struct_getSQLTypeName));
+	check_java_exception_and_rethrow(env);
+	auto typeName = jstring_to_string(env, jstr);
 
 	duckdb::LogicalType type;
 	context.RunFunctionInTransaction([&]() { type = TransformStringToLogicalType(typeName, context); });
 
-	auto jvalues = (jobjectArray)env->CallObjectMethod(param, J_Struct_getAttributes);
+	jobjectArray jvalues = reinterpret_cast<jobjectArray>(env->CallObjectMethod(param, J_Struct_getAttributes));
+	check_java_exception_and_rethrow(env);
 
 	int size = env->GetArrayLength(jvalues);
 
@@ -144,8 +163,11 @@ static duckdb::Value create_value_from_struct(JNIEnv *env, jobject param, duckdb
 }
 
 static duckdb::Value create_value_from_array(JNIEnv *env, jobject param, duckdb::ClientContext &context) {
-	auto typeName = jstring_to_string(env, (jstring)env->CallObjectMethod(param, J_Array_getBaseTypeName));
-	auto jvalues = (jobjectArray)env->CallObjectMethod(param, J_Array_getArray);
+	jstring jstr = reinterpret_cast<jstring>(env->CallObjectMethod(param, J_Array_getBaseTypeName));
+	check_java_exception_and_rethrow(env);
+	auto typeName = jstring_to_string(env, jstr);
+	jobjectArray jvalues = reinterpret_cast<jobjectArray>(env->CallObjectMethod(param, J_Array_getArray));
+	check_java_exception_and_rethrow(env);
 	int size = env->GetArrayLength(jvalues);
 
 	duckdb::LogicalType type;
@@ -163,34 +185,56 @@ static duckdb::Value create_value_from_array(JNIEnv *env, jobject param, duckdb:
 
 duckdb::Value to_duckdb_value(JNIEnv *env, jobject param, duckdb::ClientContext &context) {
 	param = env->CallStaticObjectMethod(J_Timestamp, J_Timestamp_valueOf, param);
+	check_java_exception_and_rethrow(env);
 
 	if (param == nullptr) {
 		return (duckdb::Value());
 	} else if (env->IsInstanceOf(param, J_Bool)) {
-		return (duckdb::Value::BOOLEAN(env->CallBooleanMethod(param, J_Bool_booleanValue)));
+		jboolean val = env->CallBooleanMethod(param, J_Bool_booleanValue);
+		check_java_exception_and_rethrow(env);
+		return duckdb::Value::BOOLEAN(val);
 	} else if (env->IsInstanceOf(param, J_Byte)) {
-		return (duckdb::Value::TINYINT(env->CallByteMethod(param, J_Byte_byteValue)));
+		jbyte val = env->CallByteMethod(param, J_Byte_byteValue);
+		check_java_exception_and_rethrow(env);
+		return duckdb::Value::TINYINT(val);
 	} else if (env->IsInstanceOf(param, J_Short)) {
-		return (duckdb::Value::SMALLINT(env->CallShortMethod(param, J_Short_shortValue)));
+		jshort val = env->CallShortMethod(param, J_Short_shortValue);
+		check_java_exception_and_rethrow(env);
+		return duckdb::Value::SMALLINT(val);
 	} else if (env->IsInstanceOf(param, J_Int)) {
-		return (duckdb::Value::INTEGER(env->CallIntMethod(param, J_Int_intValue)));
+		jint val = env->CallIntMethod(param, J_Int_intValue);
+		check_java_exception_and_rethrow(env);
+		return duckdb::Value::INTEGER(val);
 	} else if (env->IsInstanceOf(param, J_Long)) {
-		return (duckdb::Value::BIGINT(env->CallLongMethod(param, J_Long_longValue)));
+		jlong val = env->CallLongMethod(param, J_Long_longValue);
+		check_java_exception_and_rethrow(env);
+		return duckdb::Value::BIGINT(val);
 	} else if (env->IsInstanceOf(param, J_HugeInt)) {
 		return create_value_from_hugeint(env, param);
 	} else if (env->IsInstanceOf(param, J_TimestampTZ)) { // Check for subclass before superclass!
-		return (duckdb::Value::TIMESTAMPTZ(
-		    (duckdb::timestamp_tz_t)env->CallLongMethod(param, J_TimestampTZ_getMicrosEpoch)));
+		jlong val = env->CallLongMethod(param, J_TimestampTZ_getMicrosEpoch);
+		check_java_exception_and_rethrow(env);
+		return duckdb::Value::TIMESTAMPTZ(static_cast<duckdb::timestamp_tz_t>(val));
 	} else if (env->IsInstanceOf(param, J_DuckDBDate)) {
-		return (duckdb::Value::DATE((duckdb::date_t)env->CallLongMethod(param, J_DuckDBDate_getDaysSinceEpoch)));
+		jlong val = env->CallLongMethod(param, J_DuckDBDate_getDaysSinceEpoch);
+		check_java_exception_and_rethrow(env);
+		return duckdb::Value::DATE(static_cast<duckdb::date_t>(val));
 	} else if (env->IsInstanceOf(param, J_DuckDBTime)) {
-		return (duckdb::Value::TIME((duckdb::dtime_t)env->CallLongMethod(param, J_Timestamp_getMicrosEpoch)));
+		jlong val = env->CallLongMethod(param, J_Timestamp_getMicrosEpoch);
+		check_java_exception_and_rethrow(env);
+		return duckdb::Value::TIME(static_cast<duckdb::dtime_t>(val));
 	} else if (env->IsInstanceOf(param, J_Timestamp)) {
-		return (duckdb::Value::TIMESTAMP((duckdb::timestamp_t)env->CallLongMethod(param, J_Timestamp_getMicrosEpoch)));
+		jlong val = env->CallLongMethod(param, J_Timestamp_getMicrosEpoch);
+		check_java_exception_and_rethrow(env);
+		return duckdb::Value::TIMESTAMP(static_cast<duckdb::timestamp_t>(val));
 	} else if (env->IsInstanceOf(param, J_Float)) {
-		return (duckdb::Value::FLOAT(env->CallFloatMethod(param, J_Float_floatValue)));
+		jfloat val = env->CallFloatMethod(param, J_Float_floatValue);
+		check_java_exception_and_rethrow(env);
+		return duckdb::Value::FLOAT(val);
 	} else if (env->IsInstanceOf(param, J_Double)) {
-		return (duckdb::Value::DOUBLE(env->CallDoubleMethod(param, J_Double_doubleValue)));
+		jdouble val = env->CallDoubleMethod(param, J_Double_doubleValue);
+		check_java_exception_and_rethrow(env);
+		return duckdb::Value::DOUBLE(val);
 	} else if (env->IsInstanceOf(param, J_BigDecimal)) {
 		return create_value_from_bigdecimal(env, param);
 	} else if (env->IsInstanceOf(param, J_String)) {

--- a/src/jni/util.cpp
+++ b/src/jni/util.cpp
@@ -21,40 +21,46 @@ void check_java_exception_and_rethrow(JNIEnv *env) {
 	}
 }
 
-std::string jbyteArray_to_string(JNIEnv *env, jbyteArray ba_j) {
-	if (nullptr == ba_j) {
+std::string jbyteArray_to_string(JNIEnv *env, jbyteArray jbytes) {
+	if (nullptr == jbytes) {
 		return std::string();
 	}
-	size_t len = static_cast<size_t>(env->GetArrayLength(ba_j));
+	size_t len = static_cast<size_t>(env->GetArrayLength(jbytes));
 	if (len == 0) {
 		return std::string();
 	}
 	std::string ret;
 	ret.resize(len);
 
-	jbyte *bytes = reinterpret_cast<jbyte *>(env->GetByteArrayElements(ba_j, nullptr));
+	jbyte *bytes = reinterpret_cast<jbyte *>(env->GetByteArrayElements(jbytes, nullptr));
 	if (bytes == nullptr) {
 		env->ThrowNew(J_SQLException, "GetByteArrayElements error");
 		return std::string();
 	}
 
 	std::memcpy(&ret[0], bytes, len);
-
-	env->ReleaseByteArrayElements(ba_j, bytes, 0);
-
+	env->ReleaseByteArrayElements(jbytes, bytes, 0);
 	return ret;
 }
 
 std::string jstring_to_string(JNIEnv *env, jstring jstr) {
 	jbyteArray bytes = reinterpret_cast<jbyteArray>(env->CallObjectMethod(jstr, J_String_getBytes, J_Charset_UTF8));
-	return jbyteArray_to_string(env, bytes);
+	check_java_exception_and_rethrow(env);
+	std::string res = jbyteArray_to_string(env, bytes);
+	env->DeleteLocalRef(bytes);
+	return res;
 }
 
-jobject decode_charbuffer_to_jstring(JNIEnv *env, const char *d_str, idx_t d_str_len) {
-	auto bb = env->NewDirectByteBuffer((void *)d_str, d_str_len);
-	auto j_cb = env->CallObjectMethod(J_Charset_UTF8, J_Charset_decode, bb);
-	auto j_str = env->CallObjectMethod(j_cb, J_CharBuffer_toString);
-	return j_str;
+jstring decode_charbuffer_to_jstring(JNIEnv *env, const char *cstr, idx_t len) {
+	auto bytebuf = env->NewDirectByteBuffer(reinterpret_cast<void *>(const_cast<char *>(cstr)), len);
+	check_java_exception_and_rethrow(env);
+	auto jcharbuf = env->CallObjectMethod(J_Charset_UTF8, J_Charset_decode, bytebuf);
+	check_java_exception_and_rethrow(env);
+	env->DeleteLocalRef(bytebuf);
+	auto jstr = env->CallObjectMethod(jcharbuf, J_CharBuffer_toString);
+	check_java_exception_and_rethrow(env);
+	env->DeleteLocalRef(jcharbuf);
+	return reinterpret_cast<jstring>(jstr);
 }
 
 jlong uint64_to_jlong(uint64_t value) {
@@ -145,6 +151,9 @@ jobject make_data_buf(JNIEnv *env, void *data, idx_t len) {
 	if (data != nullptr) {
 		jobject buf = env->NewDirectByteBuffer(data, uint64_to_jlong(len));
 		env->CallObjectMethod(buf, J_ByteBuffer_order, J_ByteOrder_NATIVE);
+		if (env->ExceptionCheck()) {
+			return nullptr;
+		}
 		return buf;
 	}
 

--- a/src/jni/util.hpp
+++ b/src/jni/util.hpp
@@ -19,11 +19,11 @@ inline void varchar_deleter(char *val) {
 
 void check_java_exception_and_rethrow(JNIEnv *env);
 
-std::string jbyteArray_to_string(JNIEnv *env, jbyteArray ba_j);
+std::string jbyteArray_to_string(JNIEnv *env, jbyteArray jbytes);
 
 std::string jstring_to_string(JNIEnv *env, jstring string_j);
 
-jobject decode_charbuffer_to_jstring(JNIEnv *env, const char *d_str, idx_t d_str_len);
+jstring decode_charbuffer_to_jstring(JNIEnv *env, const char *cstr, idx_t len);
 
 jlong uint64_to_jlong(uint64_t value);
 


### PR DESCRIPTION
This is a backport of the PR #731 to `v1.5-variegata` stable branch.

This PR adds more eager cleanup for local JNI references. Additionally it adds a few more exception checks after calling Java methods from native.

Testing: no functional changes, no new tests.

Fixes: #730