### PR TITLE
Add JDBC instance cache option (1.5)

### DIFF
--- a/src/jni/duckdb_java.cpp
+++ b/src/jni/duckdb_java.cpp
@@ -69,11 +69,12 @@ JNIEXPORT void JNICALL JNI_OnUnload(JavaVM *vm, void *reserved) {
 //! The database instance cache, used so that multiple connections to the same file point to the same database object
 duckdb::DBInstanceCache instance_cache;
 
-jobject _duckdb_jdbc_startup(JNIEnv *env, jclass, jbyteArray database_j, jboolean read_only, jobject props) {
+jobject _duckdb_jdbc_startup(JNIEnv *env, jclass, jbyteArray database_j, jboolean read_only, jobject props,
+                             jboolean cache_instance) {
 	auto database = jbyteArray_to_string(env, database_j);
 	std::unique_ptr<DBConfig> config = create_db_config(env, read_only, props);
-	bool cache_instance = database != ":memory:" && !database.empty();
-	auto shared_db = instance_cache.GetOrCreateInstance(database, *config, cache_instance);
+	bool should_cache = cache_instance && database != ":memory:" && !database.empty();
+	auto shared_db = instance_cache.GetOrCreateInstance(database, *config, should_cache);
 	auto conn_ref = new ConnectionHolder(shared_db);
 
 	return env->NewDirectByteBuffer(conn_ref, 0);

--- a/src/jni/functions.cpp
+++ b/src/jni/functions.cpp
@@ -4,9 +4,9 @@
 #include "functions.hpp"
 #include <exception>
 
-JNIEXPORT jobject JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1startup(JNIEnv * env, jclass param0, jbyteArray param1, jboolean param2, jobject param3) {
+JNIEXPORT jobject JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1startup(JNIEnv * env, jclass param0, jbyteArray param1, jboolean param2, jobject param3, jboolean param4) {
 	try {
-		return _duckdb_jdbc_startup(env, param0, param1, param2, param3);
+		return _duckdb_jdbc_startup(env, param0, param1, param2, param3, param4);
 	} catch (const std::exception &e) {
 		duckdb::ErrorData error(e);
 		ThrowJNI(env, error.Message().c_str());

--- a/src/jni/functions.hpp
+++ b/src/jni/functions.hpp
@@ -9,9 +9,9 @@
 
 void ThrowJNI(JNIEnv* env, const char* message);
 
-jobject _duckdb_jdbc_startup(JNIEnv * env, jclass param0, jbyteArray param1, jboolean param2, jobject param3);
+jobject _duckdb_jdbc_startup(JNIEnv * env, jclass param0, jbyteArray param1, jboolean param2, jobject param3, jboolean param4);
 
-JNIEXPORT jobject JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1startup(JNIEnv * env, jclass param0, jbyteArray param1, jboolean param2, jobject param3);
+JNIEXPORT jobject JNICALL Java_org_duckdb_DuckDBNative_duckdb_1jdbc_1startup(JNIEnv * env, jclass param0, jbyteArray param1, jboolean param2, jobject param3, jboolean param4);
 
 jobject _duckdb_jdbc_connect(JNIEnv * env, jclass param0, jobject param1);
 

--- a/src/main/java/org/duckdb/DuckDBConnection.java
+++ b/src/main/java/org/duckdb/DuckDBConnection.java
@@ -81,7 +81,10 @@ public final class DuckDBConnection implements java.sql.Connection {
         String autoCommitStr = removeOption(properties, JDBC_AUTO_COMMIT);
         boolean autoCommit = isStringTruish(autoCommitStr, true);
         String monitorName = removeOption(properties, DuckDBDriver.JDBC_JFR_MEMORY_MONITOR);
-        ByteBuffer nativeReference = DuckDBNative.duckdb_jdbc_startup(dbName.getBytes(UTF_8), readOnly, properties);
+        String instanceCacheStr = removeOption(properties, DuckDBDriver.JDBC_INSTANCE_CACHE);
+        boolean instanceCache = isStringTruish(instanceCacheStr, true);
+        ByteBuffer nativeReference =
+            DuckDBNative.duckdb_jdbc_startup(dbName.getBytes(UTF_8), readOnly, properties, instanceCache);
         return new DuckDBConnection(nativeReference, url, readOnly, sessionInitSQL, autoCommit, monitorName);
     }
 

--- a/src/main/java/org/duckdb/DuckDBDriver.java
+++ b/src/main/java/org/duckdb/DuckDBDriver.java
@@ -30,6 +30,7 @@ public class DuckDBDriver implements java.sql.Driver {
     public static final String JDBC_STREAM_RESULTS = "jdbc_stream_results";
     public static final String JDBC_AUTO_COMMIT = "jdbc_auto_commit";
     public static final String JDBC_PIN_DB = "jdbc_pin_db";
+    public static final String JDBC_INSTANCE_CACHE = "jdbc_instance_cache";
     public static final String JDBC_IGNORE_UNSUPPORTED_OPTIONS = "jdbc_ignore_unsupported_options";
     public static final String JDBC_JFR_MEMORY_MONITOR = "jdbc_jfr_memory_monitor";
 
@@ -169,6 +170,10 @@ public class DuckDBDriver implements java.sql.Driver {
         list.add(createDriverPropInfo(JDBC_AUTO_COMMIT, "", "Set default auto-commit mode"));
         list.add(createDriverPropInfo(JDBC_PIN_DB, "",
                                       "Do not close the DB instance after all connections to it are closed"));
+        list.add(createDriverPropInfo(JDBC_INSTANCE_CACHE, "",
+                                      "Reuse the process-wide DuckDB instance for the same database path. Disabling "
+                                          + "creates an isolated instance per connection and may cause local file lock "
+                                          + "conflicts. Pinning an uncached instance does not make it reusable."));
         list.add(createDriverPropInfo(JDBC_IGNORE_UNSUPPORTED_OPTIONS, "",
                                       "Silently discard unsupported connection options"));
         list.add(

--- a/src/main/java/org/duckdb/DuckDBNative.java
+++ b/src/main/java/org/duckdb/DuckDBNative.java
@@ -140,7 +140,8 @@ final class DuckDBNative {
      */
 
     // results ConnectionHolder reference object
-    static native ByteBuffer duckdb_jdbc_startup(byte[] path, boolean read_only, Properties props) throws SQLException;
+    static native ByteBuffer duckdb_jdbc_startup(byte[] path, boolean read_only, Properties props,
+                                                 boolean cache_instance) throws SQLException;
 
     // returns conn_ref connection reference object
     static native ByteBuffer duckdb_jdbc_connect(ByteBuffer conn_ref) throws SQLException;

--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -992,16 +992,44 @@ public class TestDuckDBJDBC {
     }
 
     public static void test_instance_cache() throws Exception {
-        Path database_file = Files.createTempFile("duckdb-instance-cache-test-", ".duckdb");
-        database_file.toFile().delete();
+        try (TempDirectory dir = new TempDirectory()) {
+            String fileUrl = JDBC_URL + dir.path().resolve("instance_cache.db");
+            try (DuckDBConnection conn1 = DriverManager.getConnection(fileUrl).unwrap(DuckDBConnection.class);
+                 DuckDBConnection conn2 = DriverManager.getConnection(fileUrl).unwrap(DuckDBConnection.class)) {
+                assertEquals(conn1.dbAddress, conn2.dbAddress);
+            }
+        }
 
-        String jdbc_url = JDBC_URL + database_file.toString();
+        String jdbcUrl = JDBC_URL + "memory:instance_cache_" + UUID.randomUUID();
+        try (DuckDBConnection conn1 = DriverManager.getConnection(jdbcUrl).unwrap(DuckDBConnection.class);
+             DuckDBConnection conn2 = DriverManager.getConnection(jdbcUrl).unwrap(DuckDBConnection.class)) {
+            assertEquals(conn1.dbAddress, conn2.dbAddress);
+        }
 
-        Connection conn = DriverManager.getConnection(jdbc_url);
-        Connection conn2 = DriverManager.getConnection(jdbc_url);
+        String isolatedUrl = jdbcUrl + ";" + DuckDBDriver.JDBC_INSTANCE_CACHE + "=false";
+        try (DuckDBConnection conn1 = DriverManager.getConnection(isolatedUrl).unwrap(DuckDBConnection.class);
+             DuckDBConnection conn2 = DriverManager.getConnection(isolatedUrl).unwrap(DuckDBConnection.class);
+             Statement stmt1 = conn1.createStatement(); Statement stmt2 = conn2.createStatement();
+             DuckDBConnection duplicate = conn1.duplicate()) {
+            assertTrue(conn1.dbAddress != conn2.dbAddress);
+            assertEquals(conn1.dbAddress, duplicate.dbAddress);
 
-        conn.close();
-        conn2.close();
+            stmt1.execute("ATTACH ':memory:' AS attached");
+            stmt2.execute("ATTACH ':memory:' AS attached");
+            stmt1.execute("CREATE TABLE attached.test(i INTEGER)");
+            try (PreparedStatement prepared = conn1.prepareStatement("SELECT * FROM attached.test")) {
+                prepared.executeQuery().close();
+                stmt2.execute("DETACH attached");
+                prepared.executeQuery().close();
+            }
+        }
+    }
+
+    public static void test_instance_cache_option_validation() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty(DuckDBDriver.JDBC_INSTANCE_CACHE, "maybe");
+        String message = assertThrows(() -> { DriverManager.getConnection(JDBC_URL, properties); }, SQLException.class);
+        assertTrue(message.contains("Invalid boolean option value"));
     }
 
     public static void test_user_password() throws Exception {


### PR DESCRIPTION
This is a backport of the PR #738 to `v1.5-variegata` stable branch.

Separate JDBC connections sometimes need separate DuckDB instances so instance-level state, such as attached catalogs, cannot change underneath sibling connections. This adds an opt-in `jdbc_instance_cache=false` property while keeping the current sharing behavior by default.

```java
Properties properties = new Properties();
properties.setProperty("jdbc_instance_cache", "false");

try (Connection a = DriverManager.getConnection(url, properties);
     Connection b = DriverManager.getConnection(url, properties)) {
    // a and b use independent DuckDB instances
}
```