### PR TITLE
Propagate duckdb commit and version to Java.yml

### DIFF
--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -1,6 +1,8 @@
 name: Java JDBC
 on:
   push:
+    branches-ignore:
+      - 'vendoring-*'
   pull_request:
   workflow_dispatch:
     inputs:
@@ -8,6 +10,21 @@ on:
         description: 'Skip test runs'
         required: false
         default: 'false'
+        type: 'string'
+      duckdb_sha:
+        description: 'DuckDB SHA for release event tracking'
+        required: false
+        default: ''
+        type: 'string'
+      duckdb_version:
+        description: 'DuckDB version for release event tracking'
+        required: false
+        default: ''
+        type: 'string'
+      pr_number:
+        description: 'Vendoring PR number to merge after successful CI'
+        required: false
+        default: ''
         type: 'string'
 env:
   AWS_ENDPOINT_URL: ${{ secrets.S3_DUCKDB_STAGING_ENDPOINT }}
@@ -18,6 +35,7 @@ jobs:
 
   format-check:
     name: Format Check
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'vendoring-') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -29,6 +47,7 @@ jobs:
 
   java-linux-amd64:
     name: Linux (amd64)
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'vendoring-') }}
     runs-on: ubuntu-latest
     needs: format-check
     env:
@@ -96,6 +115,7 @@ jobs:
 
   java-linux-amd64-tck:
     name: Linux TCK (amd64)
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'vendoring-') }}
     runs-on: ubuntu-latest
     needs: java-linux-amd64
     env:
@@ -158,6 +178,7 @@ jobs:
 
   java-linux-amd64-spark:
     name: Linux Spark (amd64)
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'vendoring-') }}
     runs-on: ubuntu-latest
     needs: java-linux-amd64
     env:
@@ -255,6 +276,7 @@ jobs:
 
   java-linux-amd64-asan:
     name: Linux ASan (amd64)
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'vendoring-') }}
     runs-on: ubuntu-latest
     needs: java-linux-amd64
     env:
@@ -352,6 +374,7 @@ jobs:
 
   java-linux-amd64-jepsen:
     name: Linux Jepsen (amd64)
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'vendoring-') }}
     runs-on: ubuntu-latest
     needs: java-linux-amd64
     env:
@@ -447,6 +470,7 @@ jobs:
 
   java-linux-aarch64:
     name: Linux (aarch64)
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'vendoring-') }}
     runs-on: ubuntu-24.04-arm
     needs: java-linux-amd64
     env:
@@ -508,6 +532,7 @@ jobs:
 
   java-linux-amd64-musl:
     name: Linux (amd64-musl)
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'vendoring-') }}
     runs-on: ubuntu-latest
     needs: java-linux-amd64
     env:
@@ -565,6 +590,7 @@ jobs:
 
   java-linux-aarch64-musl:
     name: Linux (aarch64-musl)
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'vendoring-') }}
     runs-on: ubuntu-24.04-arm
     needs: java-linux-amd64
     env:
@@ -622,6 +648,7 @@ jobs:
 
   java-windows-amd64:
     name: Windows (amd64)
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'vendoring-') }}
     runs-on: windows-latest
     needs: java-linux-amd64
     env:
@@ -700,6 +727,7 @@ jobs:
 
   java-windows-aarch64:
     name: Windows (aarch64)
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'vendoring-') }}
     runs-on: windows-11-arm
     needs: java-linux-amd64
     env:
@@ -782,6 +810,7 @@ jobs:
 
   java-osx-universal:
     name: macOS (Universal)
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'vendoring-') }}
     runs-on: macos-latest
     needs: java-linux-amd64
     env:
@@ -1010,10 +1039,11 @@ jobs:
         run: |
           python ./scripts/jdbc_maven_deploy_snapshot.py jdbc-artifacts .
 
-  java-merge-vendoring-pr:
-    name: Merge vendoring PR 
-    if: ${{ github.repository == 'duckdb/duckdb-java' && github.event_name == 'pull_request' && github.head_ref == format('vendoring-{0}', github.base_ref) }}
+  java-finalize-vendoring:
+    name: Finalize vendoring
+    if: ${{ always() && github.repository == 'duckdb/duckdb-java' && github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/heads/vendoring-') && inputs.pr_number != '' && inputs.duckdb_sha != '' && inputs.duckdb_version != '' }}
     needs:
+      - format-check
       - java-linux-amd64
       - java-linux-amd64-tck
       - java-linux-amd64-spark
@@ -1030,25 +1060,49 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Merge vendoring PR
         id: merge_vendoring_pr
+        if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && !contains(needs.*.result, 'skipped') }}
+        continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
-            echo "Merging PR number: ${{ github.event.pull_request.number }} with message: ${{ github.event.pull_request.title }}"
-            gh pr merge vendoring-${{ github.base_ref }} \
+            BASE_BRANCH=$(gh pr view ${{ inputs.pr_number }} --json baseRefName --jq '.baseRefName')
+            PR_TITLE=$(gh pr view ${{ inputs.pr_number }} --json title --jq '.title')
+            echo "Merging PR number: ${{ inputs.pr_number }} with message: ${PR_TITLE}"
+            gh pr merge ${{ inputs.pr_number }} \
              --rebase \
-             --subject "${{ github.event.pull_request.title }}" \
+             --subject "${PR_TITLE}" \
              --body ""
+            echo "base_branch=${BASE_BRANCH}" >> "${GITHUB_OUTPUT}"
+
+      - name: Record client status
+        if: always()
+        uses: duckdb/duckdb-workflow-trigger/dispatch@main
+        with:
+          github_token: ${{ secrets.PAT_TOKEN }}
+          event: client_ready
+          client: java
+          duckdb_version: ${{ inputs.duckdb_version }}
+          duckdb_commit: ${{ inputs.duckdb_sha }}
+          status: ${{ (contains(needs.*.result, 'failure') || steps.merge_vendoring_pr.outcome == 'failure') && 'failure' || contains(needs.*.result, 'cancelled') && 'cancelled' || contains(needs.*.result, 'skipped') && 'skipped' || 'success' }}
+          message: DuckDB Java client ready
 
       - name: Update vendoring branch
         id: update_vendoring_branch
         if: ${{ steps.merge_vendoring_pr.outcome == 'success' }}
+        continue-on-error: true
         run: |
-            # Delete vendoring-${{ github.base_ref }} branch and re-create it for future PRs
-            git push --delete origin vendoring-${{ github.base_ref }}
-            git checkout --track origin/${{ github.base_ref }}
+            BASE_BRANCH="${{ steps.merge_vendoring_pr.outputs.base_branch }}"
+            # Delete vendoring-${BASE_BRANCH} branch and re-create it for future PRs
+            git push --delete origin vendoring-${BASE_BRANCH}
+            git checkout --track origin/${BASE_BRANCH}
             git pull --ff-only
-            git branch vendoring-${{ github.base_ref }}
-            git push origin vendoring-${{ github.base_ref }}
+            git branch vendoring-${BASE_BRANCH}
+            git push origin vendoring-${BASE_BRANCH}
+
+      - name: Fail on unsuccessful final status
+        if: ${{ always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') || steps.merge_vendoring_pr.outcome == 'failure' || steps.update_vendoring_branch.outcome == 'failure') }}
+        run: exit 1

--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -1041,7 +1041,7 @@ jobs:
 
   java-finalize-vendoring:
     name: Finalize vendoring
-    if: ${{ always() && github.repository == 'duckdb/duckdb-java' && github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/heads/vendoring-') && inputs.pr_number != '' && inputs.duckdb_sha != '' && inputs.duckdb_version != '' }}
+    if: ${{ always() && github.repository == 'duckdb/duckdb-java' && github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/heads/vendoring-') && inputs.pr_number != '' && inputs.duckdb_sha != '' }}
     needs:
       - format-check
       - java-linux-amd64

--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -1060,14 +1060,13 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Merge vendoring PR
         id: merge_vendoring_pr
         if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && !contains(needs.*.result, 'skipped') }}
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
             BASE_BRANCH=$(gh pr view ${{ inputs.pr_number }} --json baseRefName --jq '.baseRefName')
             PR_TITLE=$(gh pr view ${{ inputs.pr_number }} --json title --jq '.title')

--- a/.github/workflows/Vendor.yml
+++ b/.github/workflows/Vendor.yml
@@ -7,10 +7,20 @@ on:
         required: false
         default: ''
         type: 'string'
+      duckdb-version:
+        description: 'Vendor Specific DuckDB Version'
+        required: false
+        default: ''
+        type: 'string'
   workflow_dispatch:
     inputs:
       duckdb-sha:
         description: 'Vendor Specific DuckDB SHA'
+        required: false
+        default: ''
+        type: 'string'
+      duckdb-version:
+        description: 'Vendor Specific DuckDB Version'
         required: false
         default: ''
         type: 'string'
@@ -137,6 +147,8 @@ jobs:
              --base "${{ github.ref_name }}" \
              --title "${{ steps.commit_and_push.outputs.commit_msg }}" \
              --body-file body.txt
+            PR_NUM=$(gh pr list --head vendoring-${{ github.ref_name }} --json number --jq '.[].number')
+            echo "pr_num=${PR_NUM}" >> "${GITHUB_OUTPUT}"
 
       - name: Update PR
         id: update_pr
@@ -156,6 +168,16 @@ jobs:
             gh pr edit ${{ steps.check_pr_exists.outputs.pr_num }} \
              --title "${{ steps.commit_and_push.outputs.commit_msg }}" \
              --body-file body.txt 
-            # Close and re-open the PR to trigger the tests
-            gh pr close ${{ steps.check_pr_exists.outputs.pr_num }}
-            gh pr reopen ${{ steps.check_pr_exists.outputs.pr_num }}
+
+      - name: Dispatch Java CI
+        id: dispatch_java_ci
+        if: ${{ steps.create_pr.outcome == 'success' || steps.update_pr.outcome == 'success' }}
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          PR_NUM: ${{ steps.create_pr.outputs.pr_num || steps.check_pr_exists.outputs.pr_num }}
+        run: |
+            gh workflow run Java.yml \
+             --ref vendoring-${{ github.ref_name }} \
+             -f duckdb_sha="${{ inputs.duckdb-sha }}" \
+             -f duckdb_version="${{ inputs.duckdb-version }}" \
+             -f pr_number="${PR_NUM}"


### PR DESCRIPTION
### Context

This PR is part of the [alpha](https://github.com/duckdblabs/duckdb-internal/issues/8628) release versions initiative.

The added action sends the release state of the python client back to the [release event system](https://github.com/duckdblabs/duckdb-internal/issues/9742).

See also the release event system [usage](https://github.com/duckdb/duckdb-workflow-trigger/#usage).

### Changes

I had to make some CI changes so we can propagate `workflow_dispatch` values to the CI run.

The flow is now:
1. duckdb core sends `core_ready` to Release event system.
2. Release event system [sends](https://github.com/duckdb/duckdb-workflow-trigger/blob/46784168c8ee1c92104fb0eec8a0107f248d917d/endpoints.yml#L9) a dispatch event to `duckdb/duckdb-java/Vendor.yml`
3. `Vendor` dispatches `Java.yml` with the required input parameters.
4. `Vendor.yml` sends `client_ready` back to Release event system.

Without the CI job/workflow restructuring, the values for `duckdb_version` and `duckdb_commit` were lost when we want to send the `client_ready` back.