### PR TITLE
Only allow manual snapshots publishing (1.5)

### DIFF
--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -942,7 +942,7 @@ jobs:
   # SNAPSHOTs don't require GPG signatures or validation
   # See: https://central.sonatype.org/publish/publish-portal-snapshots/
   maven-snapshot-deploy:
-    if: ${{ github.repository == 'duckdb/duckdb-java' && github.ref == 'refs/heads/v1.5-variegata' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+    if: ${{ github.repository == 'duckdb/duckdb-java' && github.ref == 'refs/heads/v1.5-variegata' && github.event_name == 'workflow_dispatch' }}
     name: Maven SNAPSHOT Deploy
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
This PR disables automatic snapshots publishing to prevent overwriting `2.0-pre` snapshots with `1.5.6-pre` snapshots.