### PR TITLE
Use OVERRIDE_GIT_DESCRIBE for correct versioning in Java.yml

### DIFF
--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -30,6 +30,7 @@ env:
   AWS_ENDPOINT_URL: ${{ secrets.S3_DUCKDB_STAGING_ENDPOINT }}
   AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
+  OVERRIDE_GIT_DESCRIBE: ${{ inputs.duckdb_version }}
 
 jobs:
 
@@ -882,7 +883,7 @@ jobs:
             build/release/duckdb_jdbc.jar
 
   maven-deploy:
-    if: ${{ github.repository == 'duckdb/duckdb-java' && inputs.override_git_describe == '' && startsWith(github.ref, 'refs/tags/') }}
+    if: ${{ github.repository == 'duckdb/duckdb-java' && inputs.duckdb_version == '' && startsWith(github.ref, 'refs/tags/') }}
     name: Maven Deploy
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
Tests are [failing](https://github.com/duckdb/duckdb-java/actions/runs/30422019252/job/90480662213#step:9:1054) in Java.yml:
```
  TestSpatial#test_spatial_WKB_BLOB failed with java.sql.SQLException: HTTP Error: Failed to download extension "spatial" at URL "http://extensions.duckdb.org/ee6ce3cd2d/linux_amd64/spatial.duckdb_extension.gz" (HTTP 404)
  Extension "spatial" is an existing extension.
  
  For more info, visit https://duckdb.org/docs/current/extensions/troubleshooting?version=ee6ce3cd2d&platform=linux_amd64&extension=spatial
  java.sql.SQLException: HTTP Error: Failed to download extension "spatial" at URL "http://extensions.duckdb.org/ee6ce3cd2d/linux_amd64/spatial.duckdb_extension.gz" (HTTP 404)
  Extension "spatial" is an existing extension.
  
  For more info, visit https://duckdb.org/docs/current/extensions/troubleshooting?version=ee6ce3cd2d&platform=linux_amd64&extension=spatial
```
because the version is not correctly propagated from Vendor.yml into the build process.

The git tag does not yet exist for duckdb core, so we need to [override](https://github.com/duckdb/duckdb/blob/7b6b4c1a586d0504b7e8d26a1f7059dba6ed4f1f/scripts/package_build.py#L156-L170) the `git describe` command with the (pre)release version.