### PR TITLE
Auto-close result returned from getResultSet

### DIFF
--- a/src/main/java/org/duckdb/DuckDBPreparedStatement.java
+++ b/src/main/java/org/duckdb/DuckDBPreparedStatement.java
@@ -53,6 +53,7 @@ public class DuckDBPreparedStatement implements PreparedStatement {
     volatile boolean closeOnCompletion = false;
 
     private DuckDBResultSet selectResult = null;
+    private boolean selectResultReturned = false;
     private long updateResult = 0;
 
     private DuckDBChunkedResult chunkedResult = null;
@@ -231,6 +232,7 @@ public class DuckDBPreparedStatement implements PreparedStatement {
             cleanupCancelQueryTask();
             DuckDBResultSetMetaData resultMeta = DuckDBNative.duckdb_jdbc_query_result_meta(resultRef);
             selectResult = new DuckDBResultSet(conn, this, resultMeta, resultRef);
+            selectResultReturned = false;
             returnsResultSet = resultMeta.return_type.equals(QUERY_RESULT);
             returnsChangedRows = resultMeta.return_type.equals(CHANGED_ROWS);
             returnsNothing = resultMeta.return_type.equals(NOTHING);
@@ -607,14 +609,13 @@ public class DuckDBPreparedStatement implements PreparedStatement {
             throw new SQLException("Statement was closed");
         }
 
-        if (!returnsResultSet) {
+        if (!returnsResultSet || selectResultReturned) {
             return null;
         }
 
         // getResultSet can only be called once per result
-        ResultSet to_return = selectResult;
-        this.selectResult = null;
-        return to_return;
+        this.selectResultReturned = true;
+        return selectResult;
     }
 
     private long getUpdateCountInternal() throws SQLException {
@@ -1374,6 +1375,7 @@ public class DuckDBPreparedStatement implements PreparedStatement {
         if (selectResult != null) {
             selectResult.close();
             selectResult = null;
+            selectResultReturned = false;
         }
         if (chunkedResult != null) {
             chunkedResult.close();

--- a/src/test/java/org/duckdb/TestClosure.java
+++ b/src/test/java/org/duckdb/TestClosure.java
@@ -110,10 +110,34 @@ public class TestClosure {
         assertTrue(stmt.isClosed());
     }
 
+    public static void test_results_execute_auto_closed_on_conn_close() throws Exception {
+        Connection conn = DriverManager.getConnection(JDBC_URL);
+        Statement stmt = conn.createStatement();
+        stmt.execute("select 42");
+        ResultSet rs = stmt.getResultSet();
+        assertNull(stmt.getResultSet());
+        rs.next();
+        conn.close();
+        assertTrue(rs.isClosed());
+        assertTrue(stmt.isClosed());
+    }
+
     public static void test_results_auto_closed_on_conn_close_prepared() throws Exception {
         Connection conn = DriverManager.getConnection(JDBC_URL);
         PreparedStatement ps = conn.prepareStatement("select 42");
         ResultSet rs = ps.executeQuery();
+        rs.next();
+        conn.close();
+        assertTrue(rs.isClosed());
+        assertTrue(ps.isClosed());
+    }
+
+    public static void test_results_execute_auto_closed_on_conn_close_prepared() throws Exception {
+        Connection conn = DriverManager.getConnection(JDBC_URL);
+        PreparedStatement ps = conn.prepareStatement("select 42");
+        ps.execute();
+        ResultSet rs = ps.getResultSet();
+        assertNull(ps.getResultSet());
         rs.next();
         conn.close();
         assertTrue(rs.isClosed());


### PR DESCRIPTION
`ResultSet` objects returned from `Statement#executeQuery()` is closed automatically, when its parent statement is closed.

Per JDBC specification:

> When a Statement object is closed, its current ResultSet object, if one exists, is also closed.

Though, when a `ResultSet` is obtained from `Statement#execute()` + `Statement.getResultSet()`, such `ResultSet` was not considered to be a "current ResultSet object" because, according to the spec:

> This method [`Statement.getResultSet()`] should be called only once per result.

Thus such result set was not closed automatically.

Such code is used in practice and it has started to cause a memory leak (of the full materialized result set) after #533 was added.

This PR fixes the leak by retaining the `ResultSet`, returned from `Statement.getResultSet()`, as a "current ResultSet object" and closing it automatically on `Statement` close.

Testing: new tests added to `TestClosure`

Fixes: #780