### PR TITLE
Promptly clean up more local JNI refs

### DIFF
--- a/src/jni/bindings_data_chunk.cpp
+++ b/src/jni/bindings_data_chunk.cpp
@@ -47,6 +47,7 @@ JNIEXPORT jobject JNICALL Java_org_duckdb_DuckDBBindings_duckdb_1create_1data_1c
 		}
 
 		duckdb_logical_type lt = logical_type_buf_to_logical_type(env, lt_buf);
+		env->DeleteLocalRef(lt_buf);
 		if (env->ExceptionCheck()) {
 			return nullptr;
 		}

--- a/src/jni/bindings_logical_type.cpp
+++ b/src/jni/bindings_logical_type.cpp
@@ -206,6 +206,7 @@ JNIEXPORT jobject JNICALL Java_org_duckdb_DuckDBBindings_duckdb_1create_1struct_
 			return nullptr;
 		}
 		duckdb_logical_type lt = logical_type_buf_to_logical_type(env, lt_buf);
+		env->DeleteLocalRef(lt_buf);
 		if (env->ExceptionCheck()) {
 			return nullptr;
 		}
@@ -227,6 +228,7 @@ JNIEXPORT jobject JNICALL Java_org_duckdb_DuckDBBindings_duckdb_1create_1struct_
 			return nullptr;
 		}
 		std::string str = jbyteArray_to_string(env, jba);
+		env->DeleteLocalRef(jba);
 		if (env->ExceptionCheck()) {
 			return nullptr;
 		}

--- a/src/jni/duckdb_java.cpp
+++ b/src/jni/duckdb_java.cpp
@@ -296,6 +296,7 @@ static duckdb::unique_ptr<QueryResult> execute_prepared_statement(JNIEnv *env, j
 		for (idx_t i = 0; i < param_len; i++) {
 			auto param = env->GetObjectArrayElement(params, i);
 			duckdb::Value val = to_duckdb_value(env, param, *context);
+			env->DeleteLocalRef(param);
 			duckdb_params.push_back(std::move(val));
 		}
 	}

--- a/src/jni/types.cpp
+++ b/src/jni/types.cpp
@@ -153,10 +153,10 @@ static duckdb::Value create_value_from_struct(JNIEnv *env, jobject param, duckdb
 
 	for (int i = 0; i < size; i++) {
 		auto name = duckdb::StructType::GetChildName(type, i);
-
-		auto value = env->GetObjectArrayElement(jvalues, i);
-
-		values.emplace_back(name, to_duckdb_value(env, value, context));
+		auto jvalue = env->GetObjectArrayElement(jvalues, i);
+		auto value = to_duckdb_value(env, jvalue, context);
+		env->DeleteLocalRef(jvalue);
+		values.emplace_back(name, std::move(value));
 	}
 
 	return duckdb::Value::STRUCT(std::move(values));
@@ -175,9 +175,10 @@ static duckdb::Value create_value_from_array(JNIEnv *env, jobject param, duckdb:
 
 	duckdb::vector<duckdb::Value> values;
 	for (int i = 0; i < size; i++) {
-		auto value = env->GetObjectArrayElement(jvalues, i);
-
-		values.emplace_back(to_duckdb_value(env, value, context));
+		auto jvalue = env->GetObjectArrayElement(jvalues, i);
+		auto value = to_duckdb_value(env, jvalue, context);
+		env->DeleteLocalRef(jvalue);
+		values.emplace_back(std::move(value));
 	}
 
 	return (duckdb::Value::LIST(type, values));


### PR DESCRIPTION
This PR is a follow-up to #731, it adds explicit clean up of local JNI references in more places. There are no functional changes.

Fixes: #789