### PR TITLE
Update vendored DuckDB sources to 2828abd8a5

### DIFF
--- a/src/duckdb/src/function/table/version/pragma_version.cpp
+++ b/src/duckdb/src/function/table/version/pragma_version.cpp
@@ -1,5 +1,5 @@
 #ifndef DUCKDB_PATCH_VERSION
-#define DUCKDB_PATCH_VERSION "0-alpha37464"
+#define DUCKDB_PATCH_VERSION "0-alpha37581"
 #endif
 #ifndef DUCKDB_MINOR_VERSION
 #define DUCKDB_MINOR_VERSION 0
@@ -8,10 +8,10 @@
 #define DUCKDB_MAJOR_VERSION 2
 #endif
 #ifndef DUCKDB_VERSION
-#define DUCKDB_VERSION "v2.0.0-alpha37464"
+#define DUCKDB_VERSION "v2.0.0-alpha37581"
 #endif
 #ifndef DUCKDB_SOURCE_ID
-#define DUCKDB_SOURCE_ID "ea53ecdca1"
+#define DUCKDB_SOURCE_ID "2828abd8a5"
 #endif
 #include "duckdb/function/table/system_functions.hpp"
 #include "duckdb/main/database.hpp"

--- a/src/duckdb/src/function/window/window_rank_function.cpp
+++ b/src/duckdb/src/function/window/window_rank_function.cpp
@@ -20,12 +20,15 @@ public:
 		if (!executor.arg_order_idx.empty()) {
 			use_framing = true;
 
-			//	If the argument order is a prefix of the partition ordering
+			//	If the argument order is the entire partition ordering
 			//	(and the optimizer is enabled), then we can just use the partition ordering.
+			//	A prefix is not sufficient because peer boundaries use all of the ordering keys.
 			auto &wexpr = executor.wexpr;
 			auto &arg_orders = executor.wexpr.ArgOrders();
+			auto &orders = wexpr.OrderBy();
 			const auto optimize = Settings::Get<EnableOptimizerSetting>(client);
-			if (!optimize || BoundWindowExpression::GetSharedOrders(wexpr.OrderBy(), arg_orders) != arg_orders.size()) {
+			const auto shared = BoundWindowExpression::GetSharedOrders(orders, arg_orders);
+			if (!optimize || shared != arg_orders.size() || arg_orders.size() != orders.size()) {
 				token_tree = make_uniq<WindowTokenTree>(client, arg_orders, executor.arg_order_idx, payload_count);
 			}
 		}


### PR DESCRIPTION
Changes:
 - [duckdb/duckdb#2828abd8a5](https://github.com/duckdb/duckdb/commit/2828abd8a5) imported at 2026-08-12 03:45:34
