### PR TITLE
Add lifecycle cleanup for table function states

### DIFF
--- a/UDF.MD
+++ b/UDF.MD
@@ -218,6 +218,38 @@ Table function callback must implement `DuckDBTableFunction` interface:
  - `localInit` (optional) - called once for every thread before the function execution, returns an object used to track thread-local state during function execution
  - `apply` - has access to bind data, global init data and local init date, writes results into output vectors, returns a number of written row, is called by the engine repeatedly until it return zero rows
 
+States that own resources can opt into deterministic cleanup by implementing
+`DuckDBTableFunctionState`:
+
+```java
+final class SourceState implements DuckDBTableFunctionState {
+    private final AutoCloseable resource;
+
+    SourceState(AutoCloseable resource) {
+        this.resource = resource;
+    }
+
+    @Override
+    public void close() throws Exception {
+        resource.close();
+    }
+}
+```
+
+After a state is successfully installed as bind, global-init, or local-init
+data, DuckDB owns its lifecycle and calls `close()` when that state is
+destroyed. This can happen after normal exhaustion, a `LIMIT`, an error,
+cancellation, or early JDBC result/statement/connection closure. Only objects
+implementing `DuckDBTableFunctionState` opt in; an object implementing only
+`AutoCloseable`, and `null`, are left unchanged.
+
+Cleanup can run on native worker threads. Local states can be closed
+concurrently, and no global ordering is guaranteed between bind, global-init,
+and local states. Make `close()` fast, idempotent, and thread-safe when it
+manages shared resources. It must not execute SQL or re-enter the same
+connection. Exceptions from `close()` are handled on a best-effort basis and
+are not propagated to the query, so record any diagnostics inside the state.
+
 To enable parallel function execution it is necessary to set desired number of threads using `info.setMaxThreads()` method during the global init call.
 Depending on the query it also may be necessary to set `preserve_insertion_order=FALSE` option ([reference](https://duckdb.org/docs/current/configuration/overview#global-configuration-options)) in connection string or in connection properties object.
 
@@ -272,4 +304,3 @@ try (Connection conn = DriverManager.getConnection("jdbc:duckdb:"); Statement st
 ```sql
 FROM java_table_basic(42, param1='foobar')
 ```
-

--- a/src/jni/bindings_table_function_bind.cpp
+++ b/src/jni/bindings_table_function_bind.cpp
@@ -132,7 +132,7 @@ JNIEXPORT void JNICALL Java_org_duckdb_DuckDBBindings_duckdb_1bind_1set_1bind_1d
 		return;
 	}
 
-	duckdb_bind_set_bind_data(bi, bind_data_holder.release(), GlobalRefHolder::destroy);
+	duckdb_bind_set_bind_data(bi, bind_data_holder.release(), GlobalRefHolder::destroy_table_function_state);
 }
 
 /*

--- a/src/jni/bindings_table_function_init.cpp
+++ b/src/jni/bindings_table_function_init.cpp
@@ -60,7 +60,7 @@ JNIEXPORT void JNICALL Java_org_duckdb_DuckDBBindings_duckdb_1init_1set_1init_1d
 		return;
 	}
 
-	duckdb_init_set_init_data(ii, init_data_holder.release(), GlobalRefHolder::destroy);
+	duckdb_init_set_init_data(ii, init_data_holder.release(), GlobalRefHolder::destroy_table_function_state);
 }
 
 /*

--- a/src/jni/holders.cpp
+++ b/src/jni/holders.cpp
@@ -113,6 +113,57 @@ void GlobalRefHolder::destroy(void *holder_in) noexcept {
 	delete holder;
 }
 
+void GlobalRefHolder::destroy_table_function_state(void *holder_in) noexcept {
+	auto holder = reinterpret_cast<GlobalRefHolder *>(holder_in);
+	if (holder == nullptr) {
+		return;
+	}
+
+	try {
+		AttachedJNIEnv attached = holder->attach_current_thread();
+		if (attached.env != nullptr) {
+			try {
+				attached.env->CallStaticVoidMethod(J_DuckDBTableFunctionWrapper,
+				                                   J_DuckDBTableFunctionWrapper_closeTableFunctionState,
+				                                   holder->global_ref);
+			} catch (...) {
+				// Teardown must not allow a C++ exception to escape a native destructor.
+			}
+			try {
+				if (attached.env->ExceptionCheck()) {
+					attached.env->ExceptionClear();
+				}
+			} catch (...) {
+				// JNI cleanup is best effort; the holder is still deleted below.
+			}
+			// Keep the callback's attachment alive through reference deletion and holder destruction.
+			try {
+				if (holder->global_ref != nullptr) {
+					jobject global_ref = holder->global_ref;
+					holder->global_ref = nullptr;
+					attached.env->DeleteGlobalRef(global_ref);
+				}
+			} catch (...) {
+				// The reference was cleared before the JNI call, so the holder destructor cannot
+				// redundantly attempt another attach if the call fails unexpectedly.
+			}
+			delete holder;
+			return;
+		}
+
+		// attach_current_thread already attempted the only safe cleanup path. Without a valid
+		// JNIEnv, JNI does not permit DeleteGlobalRef; clear the reference so the holder destructor
+		// does not redundantly attempt another attach.
+		holder->global_ref = nullptr;
+	} catch (...) {
+		// A failed attach or unexpected JNI failure must not skip holder deletion or trigger a
+		// second attach from the holder destructor.
+		holder->global_ref = nullptr;
+	}
+
+	delete holder;
+}
+
 LocalRefHolder::LocalRefHolder(JNIEnv *env_in, jobject local_ref_in) : env(env_in), local_ref(local_ref_in) {
 }
 

--- a/src/jni/holders.hpp
+++ b/src/jni/holders.hpp
@@ -80,6 +80,7 @@ struct GlobalRefHolder {
 	void detach_current_thread();
 
 	static void destroy(void *holder_in) noexcept;
+	static void destroy_table_function_state(void *holder_in) noexcept;
 };
 
 struct LocalRefHolder {

--- a/src/jni/refs.cpp
+++ b/src/jni/refs.cpp
@@ -123,6 +123,7 @@ jmethodID J_DuckDBTableFunctionWrapper_executeBind;
 jmethodID J_DuckDBTableFunctionWrapper_executeGlobalInit;
 jmethodID J_DuckDBTableFunctionWrapper_executeLocalInit;
 jmethodID J_DuckDBTableFunctionWrapper_executeFunction;
+jmethodID J_DuckDBTableFunctionWrapper_closeTableFunctionState;
 
 static std::vector<jobject> global_refs;
 
@@ -318,6 +319,8 @@ void create_refs(JNIEnv *env) {
 	    get_method_id(env, J_DuckDBTableFunctionWrapper, "executeLocalInit", "(Ljava/nio/ByteBuffer;)V");
 	J_DuckDBTableFunctionWrapper_executeFunction = get_method_id(env, J_DuckDBTableFunctionWrapper, "executeFunction",
 	                                                             "(Ljava/nio/ByteBuffer;Ljava/nio/ByteBuffer;)V");
+	J_DuckDBTableFunctionWrapper_closeTableFunctionState =
+	    get_static_method_id(env, J_DuckDBTableFunctionWrapper, "closeTableFunctionState", "(Ljava/lang/Object;)V");
 }
 
 void delete_global_refs(JNIEnv *env) noexcept {

--- a/src/jni/refs.hpp
+++ b/src/jni/refs.hpp
@@ -120,6 +120,7 @@ extern jmethodID J_DuckDBTableFunctionWrapper_executeBind;
 extern jmethodID J_DuckDBTableFunctionWrapper_executeGlobalInit;
 extern jmethodID J_DuckDBTableFunctionWrapper_executeLocalInit;
 extern jmethodID J_DuckDBTableFunctionWrapper_executeFunction;
+extern jmethodID J_DuckDBTableFunctionWrapper_closeTableFunctionState;
 
 void create_refs(JNIEnv *env);
 

--- a/src/main/java/org/duckdb/DuckDBTableFunctionState.java
+++ b/src/main/java/org/duckdb/DuckDBTableFunctionState.java
@@ -1,0 +1,42 @@
+package org.duckdb;
+
+/**
+ * Opt-in lifecycle contract for state returned by a {@link DuckDBTableFunction}.
+ *
+ * <p>DuckDB takes ownership of an object implementing this interface after the
+ * object has been successfully installed as bind, global-init, or local-init
+ * data. DuckDB then makes a best-effort call to {@link #close()} when the
+ * corresponding native state is destroyed. A {@code null} state and an object
+ * that does not implement this interface are not closed by this lifecycle.
+ * Implementations must not rely on garbage collection for releasing their
+ * resources.</p>
+ *
+ * <p>Teardown may run on a native execution or worker thread rather than the
+ * thread that created the state. Local states can be created and closed
+ * concurrently with one another. There is no global ordering guarantee among
+ * bind, global-init, and local-init states, or among local states.</p>
+ *
+ * <p>A holder is closed at most once, but the same Java object may be installed
+ * in multiple holders and consequently have {@code close()} called once per
+ * holder. Implementations should therefore be idempotent and thread-safe when
+ * they manage shared resources or may be aliased. {@code close()} must not
+ * re-enter the same connection or execute SQL during teardown.</p>
+ *
+ * <p>Exceptions and other {@link Throwable}s from teardown are handled on a
+ * best-effort basis and are not propagated to the query caller. Implementations
+ * that need diagnostics must record them themselves. A close failure must not
+ * prevent other state cleanup or release of the native/JNI reference.</p>
+ */
+@SuppressWarnings("try")
+public interface DuckDBTableFunctionState extends AutoCloseable {
+    /**
+     * Releases resources owned by this table-function state.
+     *
+     * <p>This method may be called from a different thread, and its failure is
+     * not reported through the query.</p>
+     *
+     * @throws Exception if releasing the resource fails; the exception is
+     *                   handled as best effort by the table-function runtime
+     */
+    @Override void close() throws Exception;
+}

--- a/src/main/java/org/duckdb/DuckDBTableFunctionWrapper.java
+++ b/src/main/java/org/duckdb/DuckDBTableFunctionWrapper.java
@@ -13,6 +13,17 @@ class DuckDBTableFunctionWrapper {
         this.function = function;
     }
 
+    static void closeTableFunctionState(Object state) {
+        if (!(state instanceof DuckDBTableFunctionState)) {
+            return;
+        }
+        try {
+            ((DuckDBTableFunctionState) state).close();
+        } catch (Throwable ignored) {
+            // State cleanup is best effort because the query may already be finished.
+        }
+    }
+
     public void executeBind(ByteBuffer bindInfoRef) {
         try {
             DuckDBTableFunctionBindInfo bindInfo = new DuckDBTableFunctionBindInfo(bindInfoRef);

--- a/src/test/java/org/duckdb/TestTableFunctions.java
+++ b/src/test/java/org/duckdb/TestTableFunctions.java
@@ -11,12 +11,125 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import org.duckdb.DuckDBFunctions.FunctionException;
 
 public class TestTableFunctions {
+
+    private static final AtomicInteger LIFECYCLE_FUNCTION_ID = new AtomicInteger();
+
+    @SuppressWarnings("try")
+    private static final class TrackingState implements DuckDBTableFunctionState {
+        private final boolean throwOnClose;
+        private final AtomicInteger closeCalls = new AtomicInteger();
+
+        TrackingState(boolean throwOnClose) {
+            this.throwOnClose = throwOnClose;
+        }
+
+        @Override
+        public void close() throws Exception {
+            closeCalls.incrementAndGet();
+            if (throwOnClose) {
+                throw new Exception("table function state close failure");
+            }
+        }
+    }
+
+    private static final class LifecycleTracker {
+        final boolean failInApply;
+        final boolean parallel;
+        final long rows;
+        final boolean throwOnClose;
+        final AtomicLong remaining = new AtomicLong();
+        final ConcurrentLinkedQueue<TrackingState> bindStates = new ConcurrentLinkedQueue<>();
+        final ConcurrentLinkedQueue<TrackingState> globalStates = new ConcurrentLinkedQueue<>();
+        final ConcurrentLinkedQueue<TrackingState> localStates = new ConcurrentLinkedQueue<>();
+
+        LifecycleTracker(long rows, boolean failInApply, boolean throwOnClose, boolean parallel) {
+            this.rows = rows;
+            this.failInApply = failInApply;
+            this.throwOnClose = throwOnClose;
+            this.parallel = parallel;
+        }
+    }
+
+    private static final class PlainAutoCloseableState implements AutoCloseable {
+        final AtomicInteger closeCalls = new AtomicInteger();
+
+        @Override
+        public void close() {
+            closeCalls.incrementAndGet();
+        }
+    }
+
+    private static String registerLifecycleTableFunction(Connection conn, final LifecycleTracker tracker)
+        throws Exception {
+        String name = "java_table_function_state_" + LIFECYCLE_FUNCTION_ID.incrementAndGet();
+        DuckDBFunctions.tableFunction()
+            .withName(name)
+            .withFunction(new DuckDBTableFunction<TrackingState, TrackingState, TrackingState>() {
+                @Override
+                public TrackingState bind(DuckDBTableFunctionBindInfo info) throws Exception {
+                    info.addResultColumn("value", Long.TYPE);
+                    TrackingState state = new TrackingState(tracker.throwOnClose);
+                    tracker.bindStates.add(state);
+                    return state;
+                }
+
+                @Override
+                public TrackingState init(DuckDBTableFunctionInitInfo info) throws Exception {
+                    info.setMaxThreads(tracker.parallel ? Runtime.getRuntime().availableProcessors() : 1);
+                    tracker.remaining.set(tracker.rows);
+                    TrackingState state = new TrackingState(tracker.throwOnClose);
+                    tracker.globalStates.add(state);
+                    return state;
+                }
+
+                @Override
+                public TrackingState localInit(DuckDBTableFunctionInitInfo info) throws Exception {
+                    TrackingState state = new TrackingState(tracker.throwOnClose);
+                    tracker.localStates.add(state);
+                    return state;
+                }
+
+                @Override
+                public long apply(DuckDBTableFunctionCallInfo info, DuckDBDataChunkWriter output) throws Exception {
+                    if (tracker.failInApply) {
+                        throw new Exception("table function apply failure");
+                    }
+                    long written = 0;
+                    while (written < output.capacity()) {
+                        long remaining = tracker.remaining.getAndDecrement();
+                        if (remaining <= 0) {
+                            break;
+                        }
+                        output.vector(0).setLong(written++, remaining);
+                    }
+                    return written;
+                }
+            })
+            .register(conn);
+        return name;
+    }
+
+    private static void assertLifecycleStatesClosed(LifecycleTracker tracker) throws Exception {
+        assertTrue(!tracker.bindStates.isEmpty());
+        assertTrue(!tracker.globalStates.isEmpty());
+        assertTrue(!tracker.localStates.isEmpty());
+        for (TrackingState state : tracker.bindStates) {
+            assertEquals(state.closeCalls.get(), 1);
+        }
+        for (TrackingState state : tracker.globalStates) {
+            assertEquals(state.closeCalls.get(), 1);
+        }
+        for (TrackingState state : tracker.localStates) {
+            assertEquals(state.closeCalls.get(), 1);
+        }
+    }
 
     public static void test_table_function_basic() throws Exception {
         try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement()) {
@@ -395,5 +508,252 @@ public class TestTableFunctions {
             }
             assertEquals(threadsUsed.get(), Runtime.getRuntime().availableProcessors());
         }
+    }
+
+    public static void test_table_function_state_limit_cleanup() throws Exception {
+        LifecycleTracker tracker = new LifecycleTracker(1 << 16, false, false, false);
+        Connection conn = DriverManager.getConnection(JDBC_URL);
+        Statement stmt = conn.createStatement();
+        String functionName = registerLifecycleTableFunction(conn, tracker);
+        ResultSet rs = stmt.executeQuery("SELECT * FROM " + functionName + "() LIMIT 1");
+        assertTrue(rs.next());
+        rs.close();
+        rs.close();
+        stmt.close();
+        stmt.close();
+        assertTrue(tracker.remaining.get() > 0);
+        assertLifecycleStatesClosed(tracker);
+        conn.close();
+        conn.close();
+        assertLifecycleStatesClosed(tracker);
+    }
+
+    public static void test_table_function_state_normal_completion() throws Exception {
+        LifecycleTracker tracker = new LifecycleTracker(17, false, false, false);
+        Connection conn = DriverManager.getConnection(JDBC_URL);
+        Statement stmt = conn.createStatement();
+        String functionName = registerLifecycleTableFunction(conn, tracker);
+        try (ResultSet rs = stmt.executeQuery("FROM " + functionName + "()")) {
+            long rows = 0;
+            while (rs.next()) {
+                rows++;
+            }
+            assertEquals(rows, 17L);
+        }
+        stmt.close();
+        assertLifecycleStatesClosed(tracker);
+        conn.close();
+    }
+
+    public static void test_table_function_state_apply_error_cleanup() throws Exception {
+        LifecycleTracker tracker = new LifecycleTracker(17, true, false, false);
+        Connection conn = DriverManager.getConnection(JDBC_URL);
+        Statement stmt = conn.createStatement();
+        String functionName = registerLifecycleTableFunction(conn, tracker);
+        assertThrows(() -> {
+            try (ResultSet rs = stmt.executeQuery("FROM " + functionName + "()")) {
+                rs.next();
+            }
+        }, java.sql.SQLException.class);
+        stmt.close();
+        assertLifecycleStatesClosed(tracker);
+        conn.close();
+    }
+
+    public static void test_table_function_state_connection_cleanup() throws Exception {
+        LifecycleTracker tracker = new LifecycleTracker(1 << 16, false, false, false);
+        Connection conn = DriverManager.getConnection(JDBC_URL + ";jdbc_stream_results=true");
+        Statement stmt = conn.createStatement();
+        String functionName = registerLifecycleTableFunction(conn, tracker);
+        ResultSet rs = stmt.executeQuery("SELECT * FROM " + functionName + "() LIMIT 1");
+        assertTrue(rs.next());
+        conn.close();
+        assertTrue(tracker.remaining.get() > 0);
+        assertLifecycleStatesClosed(tracker);
+    }
+
+    public static void test_table_function_state_close_exception_suppressed() throws Exception {
+        LifecycleTracker tracker = new LifecycleTracker(1, false, true, false);
+        Connection conn = DriverManager.getConnection(JDBC_URL);
+        Statement stmt = conn.createStatement();
+        String functionName = registerLifecycleTableFunction(conn, tracker);
+        try (ResultSet rs = stmt.executeQuery("FROM " + functionName + "()")) {
+            assertTrue(rs.next());
+            assertFalse(rs.next());
+        }
+        stmt.close();
+
+        try (Statement subsequent = conn.createStatement(); ResultSet rs = subsequent.executeQuery("SELECT 42")) {
+            assertTrue(rs.next());
+            assertEquals(rs.getInt(1), 42);
+            assertFalse(rs.next());
+        }
+        conn.close();
+        assertLifecycleStatesClosed(tracker);
+    }
+
+    public static void test_table_function_state_requires_marker() throws Exception {
+        PlainAutoCloseableState bindState = new PlainAutoCloseableState();
+        PlainAutoCloseableState globalState = new PlainAutoCloseableState();
+        PlainAutoCloseableState localState = new PlainAutoCloseableState();
+        String functionName = "java_table_function_plain_state_" + LIFECYCLE_FUNCTION_ID.incrementAndGet();
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement()) {
+            DuckDBFunctions.tableFunction()
+                .withName(functionName)
+                .withFunction(new DuckDBTableFunction<PlainAutoCloseableState, PlainAutoCloseableState,
+                                                      PlainAutoCloseableState>() {
+                    @Override
+                    public PlainAutoCloseableState bind(DuckDBTableFunctionBindInfo info) throws Exception {
+                        info.addResultColumn("value", Integer.TYPE);
+                        return bindState;
+                    }
+
+                    @Override
+                    public PlainAutoCloseableState init(DuckDBTableFunctionInitInfo info) throws Exception {
+                        info.setMaxThreads(1);
+                        return globalState;
+                    }
+
+                    @Override
+                    public PlainAutoCloseableState localInit(DuckDBTableFunctionInitInfo info) throws Exception {
+                        return localState;
+                    }
+
+                    @Override
+                    public long apply(DuckDBTableFunctionCallInfo info, DuckDBDataChunkWriter output) throws Exception {
+                        return 0;
+                    }
+                })
+                .register(conn);
+            try (ResultSet rs = stmt.executeQuery("FROM " + functionName + "()")) {
+                assertFalse(rs.next());
+            }
+        }
+        assertEquals(bindState.closeCalls.get(), 0);
+        assertEquals(globalState.closeCalls.get(), 0);
+        assertEquals(localState.closeCalls.get(), 0);
+    }
+
+    public static void test_table_function_state_alias_closes_per_holder() throws Exception {
+        TrackingState alias = new TrackingState(false);
+        String functionName = "java_table_function_alias_state_" + LIFECYCLE_FUNCTION_ID.incrementAndGet();
+        Connection conn = DriverManager.getConnection(JDBC_URL);
+        Statement stmt = conn.createStatement();
+        DuckDBFunctions.tableFunction()
+            .withName(functionName)
+            .withFunction(new DuckDBTableFunction<TrackingState, TrackingState, Object>() {
+                @Override
+                public TrackingState bind(DuckDBTableFunctionBindInfo info) throws Exception {
+                    info.addResultColumn("value", Integer.TYPE);
+                    return alias;
+                }
+
+                @Override
+                public TrackingState init(DuckDBTableFunctionInitInfo info) throws Exception {
+                    info.setMaxThreads(1);
+                    return alias;
+                }
+
+                @Override
+                public long apply(DuckDBTableFunctionCallInfo info, DuckDBDataChunkWriter output) throws Exception {
+                    return 0;
+                }
+            })
+            .register(conn);
+        try (ResultSet rs = stmt.executeQuery("FROM " + functionName + "()")) {
+            assertFalse(rs.next());
+        }
+        stmt.close();
+        conn.close();
+        assertEquals(alias.closeCalls.get(), 2);
+    }
+
+    public static void test_table_function_state_null_and_common() throws Exception {
+        String nullFunctionName = "java_table_function_null_state_" + LIFECYCLE_FUNCTION_ID.incrementAndGet();
+        String commonFunctionName = "java_table_function_common_state_" + LIFECYCLE_FUNCTION_ID.incrementAndGet();
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement()) {
+            registerObjectStateTableFunction(conn, nullFunctionName, null, null, null);
+            registerObjectStateTableFunction(conn, commonFunctionName, new Object(), new Object(), new Object());
+            try (ResultSet rs = stmt.executeQuery("FROM " + nullFunctionName + "()")) {
+                assertFalse(rs.next());
+            }
+            try (ResultSet rs = stmt.executeQuery("FROM " + commonFunctionName + "()")) {
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    public static void test_table_function_state_streaming_result_close() throws Exception {
+        LifecycleTracker tracker = new LifecycleTracker(1 << 16, false, false, false);
+        Connection conn = DriverManager.getConnection(JDBC_URL + ";jdbc_stream_results=true");
+        Statement stmt = conn.createStatement();
+        String functionName = registerLifecycleTableFunction(conn, tracker);
+        try (ResultSet rs = stmt.executeQuery("SELECT * FROM " + functionName + "() LIMIT 1")) {
+            assertTrue(rs.next());
+        }
+        stmt.close();
+        conn.close();
+        assertTrue(tracker.remaining.get() > 0);
+        assertLifecycleStatesClosed(tracker);
+    }
+
+    public static void test_table_function_state_repeated_cleanup() throws Exception {
+        LifecycleTracker tracker = new LifecycleTracker(17, false, false, false);
+        try (Connection conn = DriverManager.getConnection(JDBC_URL); Statement stmt = conn.createStatement()) {
+            String functionName = registerLifecycleTableFunction(conn, tracker);
+            for (int execution = 0; execution < 2; execution++) {
+                try (ResultSet rs = stmt.executeQuery("FROM " + functionName + "()")) {
+                    while (rs.next()) {
+                        // Consume the result so every execution reaches normal exhaustion.
+                    }
+                }
+            }
+            assertLifecycleStatesClosed(tracker);
+        }
+    }
+
+    public static void test_table_function_state_local_parallel_cleanup() throws Exception {
+        LifecycleTracker tracker = new LifecycleTracker(1 << 16, false, false, true);
+        Connection conn = DriverManager.getConnection(JDBC_URL + ";preserve_insertion_order=false");
+        Statement stmt = conn.createStatement();
+        String functionName = registerLifecycleTableFunction(conn, tracker);
+        try (ResultSet rs = stmt.executeQuery("FROM " + functionName + "()")) {
+            while (rs.next()) {
+                // Consume all rows to let every worker finish.
+            }
+        }
+        stmt.close();
+        assertLifecycleStatesClosed(tracker);
+        conn.close();
+    }
+
+    private static void registerObjectStateTableFunction(Connection conn, String functionName, Object bindState,
+                                                         Object globalState, Object localState) throws Exception {
+        DuckDBFunctions.tableFunction()
+            .withName(functionName)
+            .withFunction(new DuckDBTableFunction<Object, Object, Object>() {
+                @Override
+                public Object bind(DuckDBTableFunctionBindInfo info) throws Exception {
+                    info.addResultColumn("value", Integer.TYPE);
+                    return bindState;
+                }
+
+                @Override
+                public Object init(DuckDBTableFunctionInitInfo info) throws Exception {
+                    info.setMaxThreads(1);
+                    return globalState;
+                }
+
+                @Override
+                public Object localInit(DuckDBTableFunctionInitInfo info) throws Exception {
+                    return localState;
+                }
+
+                @Override
+                public long apply(DuckDBTableFunctionCallInfo info, DuckDBDataChunkWriter output) throws Exception {
+                    return 0;
+                }
+            })
+            .register(conn);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #800.

Add an opt-in lifecycle contract for Java table function state objects returned
from `bind`, global init, and local init.

States implementing the new `DuckDBTableFunctionState` interface are closed when
DuckDB destroys the corresponding native state:

```java
public interface DuckDBTableFunctionState extends AutoCloseable {
  @Override
  void close() throws Exception;
}
```
Objects implementing only AutoCloseable, regular objects, and null retain their existing behavior.

## Implementation

- Add the public DuckDBTableFunctionState marker interface.
- Add an internal Java teardown helper that catches failures as best effort.
- Register a specialized JNI delete callback for bind/global/local state.
- Attach native worker threads to the JVM when required.
- Clear unexpected pending JNI exceptions and always release the global reference.

- Keep the generic GlobalRefHolder::destroy callback unchanged for table function extra info and other references.

- Document ownership, concurrency, aliasing, and exception behavior in UDF.MD.

close() is invoked once per installed native holder. Therefore, the same Java object installed in multiple holders may receive multiple calls and should be idempotent when resources are shared.

## Tests

Added coverage for:

- normal exhaustion;
- early termination with LIMIT;
- errors from apply;
- connection-driven cleanup;
- streaming result cleanup;
- repeated JDBC close operations;
- repeated executions;
- parallel local states;
- aliased state objects;
- exceptions thrown by close;
- null and regular state objects;
- AutoCloseable objects without the marker.