### PR TITLE
Add a check to chunked result reader

### DIFF
--- a/src/main/java/org/duckdb/DuckDBChunkedResult.java
+++ b/src/main/java/org/duckdb/DuckDBChunkedResult.java
@@ -4,6 +4,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.duckdb.DuckDBBindings.*;
 
 import java.nio.ByteBuffer;
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -33,6 +34,9 @@ public class DuckDBChunkedResult implements AutoCloseable {
             return true;
         } finally {
             resultRefLock.unlock();
+            // parent connection may have been interrupted, in this case
+            // duckdb_fetch_chunk may or may not throw
+            checkParentConnOpen();
         }
     }
 
@@ -121,6 +125,21 @@ public class DuckDBChunkedResult implements AutoCloseable {
     private void checkOpen() {
         if (isClosed()) {
             throw new IllegalStateException("Result was closed");
+        }
+    }
+
+    private void checkParentConnOpen() {
+        try {
+            Connection conn = stmt.getConnection();
+            if (null == conn) {
+                throw new IllegalStateException("Connection was closed");
+            }
+            DuckDBConnection dconn = conn.unwrap(DuckDBConnection.class);
+            if (dconn.isClosed() || dconn.closing) {
+                throw new IllegalStateException("Connection was closed");
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException(e);
         }
     }
 

--- a/src/test/java/org/duckdb/TestClosure.java
+++ b/src/test/java/org/duckdb/TestClosure.java
@@ -540,7 +540,7 @@ public class TestClosure {
                 assertThrows(() -> {
                     while (rs.nextChunk()) {
                         resultsCount[0] += rs.chunk().rowCount();
-                        Thread.sleep(50);
+                        Thread.sleep(5);
                     }
                 }, IllegalStateException.class);
                 assertTrue(resultsCount[0] > 0);

--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -2098,7 +2098,7 @@ public class TestDuckDBJDBC {
             ExecutorService executorService = Executors.newSingleThreadExecutor();
             Future<QueryProgress> future = executorService.submit(() -> {
                 try {
-                    Thread.sleep(4000);
+                    Thread.sleep(2000);
                     QueryProgress qp = stmt.getQueryProgress();
                     stmt.cancel();
                     return qp;
@@ -2118,9 +2118,11 @@ public class TestDuckDBJDBC {
 
             QueryProgress qpRunning = future.get();
             assertNotNull(qpRunning);
-            assertTrue(qpRunning.getPercentage() > 0);
-            assertTrue(qpRunning.getRowsProcessed() > 0);
-            assertTrue(qpRunning.getTotalRowsToProcess() > 0);
+            // cannot be reliable asserted under ASan
+            if (qpRunning.getPercentage() > 0) {
+                assertTrue(qpRunning.getRowsProcessed() > 0);
+                assertTrue(qpRunning.getTotalRowsToProcess() > 0);
+            }
 
             assertThrows(stmt::getQueryProgress, SQLException.class);
         }


### PR DESCRIPTION
It was discovered, that when a `DuckDBChunkedResult` is being read and the parent connection is closed concurrently - the `duckdb_fetch_chunk` native call returns a null chunk the same way as when the result is
exhausted. Thus, depending on timing, the concurrent closure may or may not cause the result set reading to throw and error.

This PR adds explicit check at result set read exit that the parent connection is still intact.

Additionally it relaxes the check in `test_query_progress` that appeared to be too slow under ASan and too fast on macOS.