### PR TITLE
[packaging] split native libs from the main jar

### DIFF
--- a/.github/composite-actions/linux-build-musl-docker/action.yml
+++ b/.github/composite-actions/linux-build-musl-docker/action.yml
@@ -18,6 +18,7 @@ runs:
           -e CC='ccache gcc'                       \
           -e CXX='ccache g++'                      \
           -e CCACHE_DIR=/duckdb/ccache             \
+          -e OVERRIDE_JDBC_LIBC=musl               \
           -e JAVA_HOME=/usr/lib/jvm/java-8-openjdk \
           ${{ inputs.docker_image }}                  \
           sh -c "

--- a/.github/composite-actions/linux-tests-docker/action.yml
+++ b/.github/composite-actions/linux-tests-docker/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'Docker image name'
     required: true
     default: ''
+  native-jar:
+    description: 'Name of the platform-native JAR produced by CMake (duckdb_jdbc_native_<os>_<arch>.jar)'
+    required: true
+    default: 'duckdb_jdbc_native_linux_amd64.jar'
 
 runs:
   using: "composite"
@@ -23,7 +27,7 @@ runs:
             /usr/lib/jvm/jre-1.8.0-openjdk/bin/java -version
             cd /duckdb
             /usr/lib/jvm/jre-1.8.0-openjdk/bin/java                                     \
-              -cp ./build/release/duckdb_jdbc_tests.jar:./build/release/duckdb_jdbc.jar \
+              -cp ./build/release/duckdb_jdbc_tests.jar:./build/release/duckdb_jdbc.jar:./build/release/${{ inputs.native-jar }} \
               org.duckdb.TestDuckDBJDBC
             rm ./test1.db
           "

--- a/.github/composite-actions/linux-tests-host/action.yml
+++ b/.github/composite-actions/linux-tests-host/action.yml
@@ -1,6 +1,12 @@
 name: 'Linux Tests Host'
 description: 'Linux test run in host OS'
 
+inputs:
+  native-jar:
+    description: 'Name of the platform-native JAR produced by CMake (duckdb_jdbc_native_<os>_<arch>.jar)'
+    required: true
+    default: 'duckdb_jdbc_native_linux_amd64.jar'
+
 runs:
   using: "composite"
   steps:
@@ -16,5 +22,5 @@ runs:
         cat /etc/os-release
         java -version
         java                                                \
-          -cp ./build/release/duckdb_jdbc_tests.jar:./build/release/duckdb_jdbc.jar \
+          -cp ./build/release/duckdb_jdbc_tests.jar:./build/release/duckdb_jdbc.jar:./build/release/${{ inputs.native-jar }} \
           org.duckdb.TestDuckDBJDBC

--- a/.github/composite-actions/linux-tests-musl-docker/action.yml
+++ b/.github/composite-actions/linux-tests-musl-docker/action.yml
@@ -15,6 +15,7 @@ runs:
         docker run                                 \
           -v.:/duckdb                              \
           -e GEN=ninja                             \
+          -e OVERRIDE_JDBC_LIBC=musl               \
           -e JAVA_HOME=/usr/lib/jvm/java-8-openjdk \
           ${{ inputs.docker_image }}               \
           sh -c "

--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -91,16 +91,20 @@ jobs:
         uses: ./.github/composite-actions/linux-tests-docker
         with:
           docker_image: '${{ env.MANYLINUX_IMAGE }}'
+          native-jar: 'duckdb_jdbc_native_linux_amd64.jar'
 
       - name: JDBC Tests
         if: ${{ inputs.skip_tests != 'true' }}
         uses: ./.github/composite-actions/linux-tests-host
+        with:
+          native-jar: 'duckdb_jdbc_native_linux_amd64.jar'
 
       - uses: actions/upload-artifact@v4
         with:
           name: java-linux-amd64
           path: |
             build/release/duckdb_jdbc.jar
+            build/release/duckdb_jdbc_native_linux_amd64.jar
 
   java-linux-amd64-tck:
     name: Linux TCK (amd64)
@@ -153,7 +157,7 @@ jobs:
           docker run                                           \
           -v.:/duckdb                                          \
           -e JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk         \
-          -e DUCKDB_JAR=/duckdb/build/release/duckdb_jdbc.jar  \
+          -e DUCKDB_JAR=/duckdb/build/release/duckdb_jdbc.jar:/duckdb/build/release/duckdb_jdbc_native_linux_amd64.jar  \
           -e PLATFORM_TCK_DIR=/duckdb/platform-tck             \
           ${{ env.MANYLINUX_IMAGE }}                           \
           bash -c "
@@ -170,7 +174,7 @@ jobs:
     needs: java-linux-amd64
     env:
       MANYLINUX_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
-      DUCKDB_JDBC_JAR: ${{ github.workspace }}/build/release/duckdb_jdbc.jar
+      DUCKDB_JDBC_JAR: ${{ github.workspace }}/build/release/duckdb_jdbc.jar${{ ':' }}${{ github.workspace }}/build/release/duckdb_jdbc_native_linux_amd64.jar
       SPARK_SQL_EXE: ${{ github.workspace }}/sparktest/spark-3.5.3-bin-hadoop3/bin/spark-sql
       POSTGRES_HOST: 127.0.0.1
       POSTGRES_PORT: 5432
@@ -418,7 +422,13 @@ jobs:
           mvn -B -ntp install:install-file \
             -Dfile=${{ github.workspace }}/build/release/duckdb_jdbc.jar \
             -DgroupId=org.duckdb \
-            -DartifactId=duckdb_jdbc \
+            -DartifactId=duckdb_jdbc_java \
+            -Dversion=1-jepsen \
+            -Dpackaging=jar
+          mvn -B -ntp install:install-file \
+            -Dfile=${{ github.workspace }}/build/release/duckdb_jdbc_native_linux_amd64.jar \
+            -DgroupId=org.duckdb \
+            -DartifactId=duckdb_jdbc_linux_amd64 \
             -Dversion=1-jepsen \
             -Dpackaging=jar
 
@@ -497,16 +507,20 @@ jobs:
         uses: ./.github/composite-actions/linux-tests-docker
         with:
           docker_image: '${{ env.MANYLINUX_IMAGE }}'
+          native-jar: 'duckdb_jdbc_native_linux_arm64.jar'
 
       - name: JDBC Tests
         if: ${{ inputs.skip_tests != 'true' }}
         uses: ./.github/composite-actions/linux-tests-host
+        with:
+          native-jar: 'duckdb_jdbc_native_linux_arm64.jar'
 
       - uses: actions/upload-artifact@v4
         with:
           name: java-linux-aarch64
           path: |
             build/release/duckdb_jdbc.jar
+            build/release/duckdb_jdbc_native_linux_arm64.jar
 
   java-linux-amd64-musl:
     name: Linux (amd64-musl)
@@ -558,6 +572,7 @@ jobs:
           name: java-linux-amd64-musl
           path: |
             build/release/duckdb_jdbc.jar
+            build/release/duckdb_jdbc_native_linux_amd64_musl.jar
 
   java-linux-aarch64-musl:
     name: Linux (aarch64-musl)
@@ -609,6 +624,7 @@ jobs:
           name: java-linux-aarch64-musl
           path: |
             build/release/duckdb_jdbc.jar
+            build/release/duckdb_jdbc_native_linux_arm64_musl.jar
 
   java-windows-amd64:
     name: Windows (amd64)
@@ -681,6 +697,7 @@ jobs:
           name: java-windows-amd64
           path: |
             build/release/duckdb_jdbc.jar
+            build/release/duckdb_jdbc_native_windows_amd64.jar
 
   java-windows-aarch64:
     name: Windows (aarch64)
@@ -757,6 +774,7 @@ jobs:
           name: java-windows-aarch64
           path: |
             build/release/duckdb_jdbc.jar
+            build/release/duckdb_jdbc_native_windows_arm64.jar
 
   java-osx-universal:
     name: macOS (Universal)
@@ -823,6 +841,7 @@ jobs:
           name: java-osx-universal
           path: |
             build/release/duckdb_jdbc.jar
+            build/release/duckdb_jdbc_native_osx_universal.jar
 
   maven-deploy:
     if: ${{ github.repository == 'duckdb/duckdb-java' && startsWith(github.ref, 'refs/tags/') }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -712,14 +712,32 @@ set_target_properties(duckdb_java PROPERTIES PREFIX "lib")
 
 
 # JAR packing
+#
+# Two artifacts are produced per build:
+#   - duckdb_jdbc.jar: pure-Java artifact (no native library). Native libraries are
+#     published as separate, OS/arch-classified JARs pulled in as Maven dependencies.
+#   - duckdb_jdbc_native_<OS_NAME>_<OS_ARCH>[<libc suffix>].jar: contains only the native
+#     library (libduckdb_java.so_<OS_NAME>_<OS_ARCH>) at its root, one per platform.
+#
+# glibc and musl produce binaries with the SAME .so filename, so the libc toolchain is
+# reflected in the outer native JAR classifier: musl builds set OVERRIDE_JDBC_LIBC
+# to "musl" giving e.g. duckdb_jdbc_native_linux_amd64_musl.jar.
+
+if(OVERRIDE_JDBC_LIBC)
+  set(NATIVE_CLASSIFIER "${OS_NAME}_${OS_ARCH}_${OVERRIDE_JDBC_LIBC}")
+else()
+  set(NATIVE_CLASSIFIER "${OS_NAME}_${OS_ARCH}")
+endif()
+set(NATIVE_JAR duckdb_jdbc_native_${NATIVE_CLASSIFIER}.jar)
 
 add_custom_command(
   OUTPUT dummy_jdbc_target
   DEPENDS duckdb_java duckdb_jdbc_nolib duckdb_jdbc_tests
+  COMMENT "Packaging pure-Java and native DuckDB JDBC JARs"
   COMMAND ${CMAKE_COMMAND} -E copy
           duckdb_jdbc_nolib.jar
           duckdb_jdbc.jar
-  COMMAND ${Java_JAR_EXECUTABLE} uf duckdb_jdbc.jar -C
+  COMMAND ${Java_JAR_EXECUTABLE} cf ${NATIVE_JAR} -C
           $<TARGET_FILE_DIR:duckdb_java> $<TARGET_FILE_NAME:duckdb_java>)
 
 add_custom_target(jdbc ALL DEPENDS dummy_jdbc_target)

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,27 @@ ifneq ($(OVERRIDE_JDBC_OS_ARCH),)
 	OS_ARCH_OVERRIDE=-DOVERRIDE_JDBC_OS_ARCH=$(OVERRIDE_JDBC_OS_ARCH)
 endif
 
+LIBC_OVERRIDE=
+ifneq ($(OVERRIDE_JDBC_LIBC),)
+	LIBC_OVERRIDE=-DOVERRIDE_JDBC_LIBC=$(OVERRIDE_JDBC_LIBC)
+endif
+
 PERF_ROWS?=2000000
 PERF_SAMPLES?=5
+
+# the platform classifier used for the CMake-produced native JAR
+NATIVE_UNAME:=$(shell uname -s | tr 'A-Z' 'a-z')
+NATIVE_MACHINE:=$(shell uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')
+NATIVE_CLASSIFIER?=$(NATIVE_UNAME)_$(NATIVE_MACHINE)
+ifeq ($(NATIVE_UNAME),darwin)
+	NATIVE_CLASSIFIER=osx_universal
+endif
+ifeq ($(OS),Windows_NT)
+	NATIVE_CLASSIFIER=windows_amd64
+endif
+ifneq ($(OVERRIDE_JDBC_LIBC),)
+	NATIVE_CLASSIFIER:=$(NATIVE_CLASSIFIER)_$(OVERRIDE_JDBC_LIBC)
+endif
 
 
 GENERATOR=
@@ -33,8 +52,9 @@ ifeq ($(GEN),ninja)
 endif
 
 JAR=$(JARS)/duckdb_jdbc.jar
+NATIVE_JAR=$(JARS)/duckdb_jdbc_native_$(NATIVE_CLASSIFIER).jar
 TEST_JAR=$(JARS)/duckdb_jdbc_tests.jar
-CP=$(JAR)$(SEP)$(TEST_JAR)
+CP=$(JAR)$(SEP)$(NATIVE_JAR)$(SEP)$(TEST_JAR)
 
 test: 
 	java -cp $(CP) org.duckdb.TestDuckDBJDBC
@@ -45,15 +65,15 @@ stress:
 
 debug:
 	mkdir -p build/debug
-	cd build/debug && cmake -DCMAKE_BUILD_TYPE=Debug $(GENERATOR) $(OS_NAME_OVERRIDE) $(OS_ARCH_OVERRIDE) ../.. && cmake --build . --config Debug
+	cd build/debug && cmake -DCMAKE_BUILD_TYPE=Debug $(GENERATOR) $(OS_NAME_OVERRIDE) $(OS_ARCH_OVERRIDE) $(LIBC_OVERRIDE) ../.. && cmake --build . --config Debug
 
 release:
 	mkdir -p build/release
-	cd build/release && cmake -DCMAKE_BUILD_TYPE=Release $(GENERATOR) $(OS_NAME_OVERRIDE) $(OS_ARCH_OVERRIDE) ../.. && cmake --build . --config Release
+	cd build/release && cmake -DCMAKE_BUILD_TYPE=Release $(GENERATOR) $(OS_NAME_OVERRIDE) $(OS_ARCH_OVERRIDE) $(LIBC_OVERRIDE) ../.. && cmake --build . --config Release
 
 sanitized:
 	mkdir -p build/sanitized
-	cd build/sanitized && cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_ADDRESS_SANITIZER=ON $(GENERATOR) $(OS_NAME_OVERRIDE) $(OS_ARCH_OVERRIDE) ../.. && cmake --build . --config Release
+	cd build/sanitized && cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_ADDRESS_SANITIZER=ON $(GENERATOR) $(OS_NAME_OVERRIDE) $(OS_ARCH_OVERRIDE) $(LIBC_OVERRIDE) ../.. && cmake --build . --config Release
 
 format:
 	python3 scripts/format.py

--- a/README.md
+++ b/README.md
@@ -7,18 +7,27 @@ Make sure the `JAVA_HOME` environment variable is set.
 To build the driver, run `make release`. 
 
 
-This will produce two jars in the build folder:
-`build/release/duckdb_jdbc.jar`
-`build/release/duckdb_jdbc_tests.jar`
+This produces multiple jars in the build folder:
+`build/release/duckdb_jdbc.jar` - the pure-Java artifact (no native library)
+`build/release/duckdb_jdbc_native_<os>_<arch>.jar` - the native library for the current platform
+`build/release/duckdb_jdbc_tests.jar` - the tests
 
-The tests can be ran using using `make test` or this command
+The native library is not embedded in the Java jar. When publishing to Maven, each
+platform's native library is shipped as a separate classifier artifact
+(`duckdb_jdbc-<version>-<classifier>.jar`) and pulled in by the pure-Java artifact
+via OS/arch-activated profiles. The glibc builds are the default for Linux; the musl
+variants are published but must be declared explicitly (Maven cannot detect musl at
+resolve time). See `pom.xml.template`.
+
+The tests can be ran using using `make test` (the Makefile puts the native jar on the
+classpath automatically) or this command:
 ```
-java -cp "build/release/duckdb_jdbc_tests.jar:build/release/duckdb_jdbc.jar" org/duckdb/TestDuckDBJDBC
+java -cp "build/release/duckdb_jdbc_tests.jar:build/release/duckdb_jdbc.jar:build/release/duckdb_jdbc_native_linux_amd64.jar" org/duckdb/TestDuckDBJDBC
 ```
 
 This optionally takes an argument to only run a single test, for example:
 ```
-java -cp "build/release/duckdb_jdbc_tests.jar:build/release/duckdb_jdbc.jar"  org/duckdb/TestDuckDBJDBC test_valid_but_local_config_throws_exception
+java -cp "build/release/duckdb_jdbc_tests.jar:build/release/duckdb_jdbc.jar:build/release/duckdb_jdbc_native_linux_amd64.jar"  org/duckdb/TestDuckDBJDBC test_valid_but_local_config_throws_exception
 ```
 
 The string write performance benchmark is optional and can be run with:
@@ -31,3 +40,76 @@ benchmark is intentionally not part of the regular test suite.
 Scalar function usage examples: [UDF.MD](UDF.MD)
 
 JFR memory monitoring usage: [JFR.md](JFR.md)
+
+### Publishing
+
+The driver is published as a set of `org.duckdb` artifacts, each with its own
+groupId/artifactId/version (GAV), instead of one jar carrying multiple classifier
+variants. Every artifact is self-contained; the native library is resolved as a
+first-class dependency.
+
+Published artifacts (version `V`):
+
+[options="header",cols="1,2,1"]
+|===
+| Artifact | Content | Notes
+| duckdb_jdbc | empty JAR | backward-compatible aggregate: a thin POM that transitively pulls `duckdb_jdbc_java` + the 4 core platform natives
+| duckdb_jdbc_java | Java classes only | ships `-sources` and `-javadoc`; declares no native dependency (pick one yourself)
+| duckdb_jdbc_linux_amd64 | Linux x86_64 (glibc) | one of the 4 aggregate defaults
+| duckdb_jdbc_linux_arm64 | Linux ARM64 (glibc) | one of the 4 aggregate defaults
+| duckdb_jdbc_macos_universal | macOS (x86_64 + ARM64) | one of the 4 aggregate defaults
+| duckdb_jdbc_windows_amd64 | Windows x86_64 | one of the 4 aggregate defaults
+| duckdb_jdbc_linux_amd64_musl | Linux x86_64 (musl) | published, opt-in (not in the aggregate)
+| duckdb_jdbc_linux_arm64_musl | Linux ARM64 (musl) | published, opt-in (not in the aggregate)
+| duckdb_jdbc_windows_arm64 | Windows ARM64 | published, opt-in (not in the aggregate)
+|===
+
+All `packaging` is `jar`; groupId is `org.duckdb`.
+
+Recommended usage:
+- Simplest: depend on `duckdb_jdbc`. Its thin POM pulls java + the 4 core platform
+  natives, and the driver loader picks the matching `.so` at runtime.
+- Pin the platform yourself: depend on `duckdb_jdbc_java` plus exactly the native
+  artifact you target (e.g. `duckdb_jdbc_linux_amd64`).
+- Alpine/musl: declare `duckdb_jdbc_linux_amd64_musl` (or `duckdb_jdbc_linux_arm64_musl`)
+  explicitly; Maven cannot detect musl, so it is not auto-selected.
+
+The poms are generated from checked-in templates at publish time (the version is the
+git tag, or a commit-derived SNAPSHOT):
+- `pom.xml.template` produces the `duckdb_jdbc` aggregate POM (thin: unconditional
+  dependencies on `duckdb_jdbc_java` + the 4 core OS natives).
+- `classifier-pom.xml.template` produces each module POM (`duckdb_jdbc_java` and every
+  native artifact) via the `${ARTIFACT_ID}` placeholder.
+
+Release flow (GitHub Actions, `.github/workflows/Java.yml`):
+- Each platform job builds and uploads `duckdb_jdbc.jar` and its
+  `duckdb_jdbc_native_<os>_<arch>.jar`.
+- `maven-deploy` (on tags) runs `scripts/jdbc_maven_deploy.py` to publish all artifacts
+  to Maven Central.
+- `maven-snapshot-deploy` (manual dispatch on `main`) runs
+  `scripts/jdbc_maven_deploy_s3.py` to publish SNAPSHOTs to the DuckDB staging S3 repo.
+
+Example - depend on everything (recommended):
+
+```
+<dependency>
+  <groupId>org.duckdb</groupId>
+  <artifactId>duckdb_jdbc</artifactId>
+  <version>V</version>
+</dependency>
+```
+
+Example - pin the platform yourself:
+
+```
+<dependency>
+  <groupId>org.duckdb</groupId>
+  <artifactId>duckdb_jdbc_java</artifactId>
+  <version>V</version>
+</dependency>
+<dependency>
+  <groupId>org.duckdb</groupId>
+  <artifactId>duckdb_jdbc_linux_amd64_musl</artifactId>
+  <version>V</version>
+</dependency>
+```

--- a/classifier-pom.xml.template
+++ b/classifier-pom.xml.template
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.duckdb</groupId>
+  <artifactId>${ARTIFACT_ID}</artifactId>
+  <version>${VERSION}</version>
+  <packaging>jar</packaging>
+  <name>DuckDB JDBC Driver - ${CLASSIFIER} native library</name>
+  <description>Native library for the DuckDB JDBC driver on the ${CLASSIFIER} platform</description>
+  <url>https://www.duckdb.org</url>
+
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>https://raw.githubusercontent.com/duckdb/duckdb/main/LICENSE</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:git://github.com/duckdb/duckdb.git</connection>
+    <developerConnection>scm:git:ssh://github.com:duckdb/duckdb.git</developerConnection>
+    <url>http://github.com/duckdb/duckdb/tree/main</url>
+  </scm>
+</project>

--- a/data/jepsen/jepsen.patch
+++ b/data/jepsen/jepsen.patch
@@ -7,7 +7,8 @@ index 89480ff..fdc1a64 100644
                   [org.clojure/tools.logging "1.3.0"]
                   [io.jepsen/generator "0.1.1"]
 -                  [org.duckdb/duckdb_jdbc "1.5.0.0"]
-+                  [org.duckdb/duckdb_jdbc "1-jepsen"]
++                  [org.duckdb/duckdb_jdbc_java "1-jepsen"]
++                  [org.duckdb/duckdb_jdbc_linux_amd64 "1-jepsen"]
                   ; Fixes a few known issues (not sure what exactly) in 1.5.0.0
                   ; [org.duckdb/duckdb_jdbc "1.5.1.0-7e03e76d-SNAPSHOT"]
                   ; Fixes the data corruption issue we found with strings!

--- a/pom.xml.template
+++ b/pom.xml.template
@@ -1,0 +1,93 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.duckdb</groupId>
+  <artifactId>duckdb_jdbc</artifactId>
+  <version>${VERSION}</version>
+  <packaging>jar</packaging>
+  <name>DuckDB JDBC Driver</name>
+  <description>A JDBC-Compliant driver for the DuckDB data management system</description>
+  <url>https://www.duckdb.org</url>
+
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>https://raw.githubusercontent.com/duckdb/duckdb/main/LICENSE</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Mark Raasveldt</name>
+      <email>mark@duckdblabs.com</email>
+      <organization>DuckDB Labs</organization>
+      <organizationUrl>https://www.duckdblabs.com</organizationUrl>
+    </developer>
+    <developer>
+      <name>Hannes Muehleisen</name>
+      <email>hannes@duckdblabs.com</email>
+      <organization>DuckDB Labs</organization>
+      <organizationUrl>https://www.duckdblabs.com</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:git://github.com/duckdb/duckdb-java.git</connection>
+    <developerConnection>scm:git:ssh://github.com:duckdb/duckdb-java.git</developerConnection>
+    <url>http://github.com/duckdb/duckdb-java/tree/main</url>
+  </scm>
+
+  <!--
+    This POM is only used to declare the runtime dependency graph and publish the
+    driver. It cannot build the JDBC driver itself (that is done by CMake).
+
+    This artifact (duckdb_jdbc) is the backward-compatible aggregate: it ships an
+    empty JAR and, through this thin POM, transitively pulls in the Java artifact
+    and the four core platform native artifacts for every platform (no OS/arch
+    profile activation, so a single dependency gives you all of them). The driver
+    loader picks the matching native library at runtime by filename.
+
+    Native libraries are each a first-class artifact:
+      - org.duckdb:duckdb_jdbc_java            - Java classes only (no native)
+      - org.duckdb:duckdb_jdbc_linux_amd64     - Linux x86_64 (glibc)
+      - org.duckdb:duckdb_jdbc_linux_arm64     - Linux ARM64 (glibc)
+      - org.duckdb:duckdb_jdbc_macos_universal - macOS (x86_64 + ARM64)
+      - org.duckdb:duckdb_jdbc_windows_amd64   - Windows x86_64
+      - org.duckdb:duckdb_jdbc_linux_amd64_musl   - Linux x86_64 (musl, opt-in)
+      - org.duckdb:duckdb_jdbc_linux_arm64_musl   - Linux ARM64 (musl, opt-in)
+      - org.duckdb:duckdb_jdbc_windows_arm64      - Windows ARM64 (opt-in)
+
+    The musl and Windows ARM64 variants are published but NOT part of this aggregate:
+    declare them explicitly to override/select a specific native library, and use
+    duckdb_jdbc_java directly when you want to pin the native artifact yourself.
+  -->
+  <dependencies>
+    <dependency>
+      <groupId>org.duckdb</groupId>
+      <artifactId>duckdb_jdbc_java</artifactId>
+      <version>${VERSION}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.duckdb</groupId>
+      <artifactId>duckdb_jdbc_linux_amd64</artifactId>
+      <version>${VERSION}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.duckdb</groupId>
+      <artifactId>duckdb_jdbc_linux_arm64</artifactId>
+      <version>${VERSION}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.duckdb</groupId>
+      <artifactId>duckdb_jdbc_macos_universal</artifactId>
+      <version>${VERSION}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.duckdb</groupId>
+      <artifactId>duckdb_jdbc_windows_amd64</artifactId>
+      <version>${VERSION}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/scripts/jdbc_maven_deploy.py
+++ b/scripts/jdbc_maven_deploy.py
@@ -16,7 +16,6 @@ import shutil
 import subprocess
 import sys
 import tempfile
-import zipfile
 import re
 import base64
 import hashlib
@@ -58,107 +57,73 @@ else:
 jdbc_artifact_dir = sys.argv[2]
 jdbc_root_path = sys.argv[3]
 
-combine_builds = ['linux-amd64', 'osx-universal', 'windows-amd64', 'linux-aarch64']
-arch_specific_builds = [
-  'linux-amd64',
-  'linux-aarch64',
-  'linux-amd64-musl',
-  'linux-aarch64-musl',
-  'osx-universal',
-  'windows-amd64',
-  'windows-aarch64',
-]
-arch_specific_classifiers = [
-  'linux_amd64',
-  'linux_arm64',
-  'linux_amd64_musl',
-  'linux_arm64_musl',
-  'macos_universal',
-  'windows_amd64',
-  'windows_arm64',
-]
+# Per CI build: (Maven classifier, name of the native JAR produced by CMake).
+# The native JAR produced by CMake is duckdb_jdbc_native_<os>_<arch>[<libc>].jar with
+# the CMake OS/arch convention (osx_universal for macOS); each is published as a
+# first-class artifact org.duckdb:duckdb_jdbc_<classifier>.
+arch_specific_builds = {
+  'linux-amd64': ('linux_amd64', 'duckdb_jdbc_native_linux_amd64.jar'),
+  'linux-aarch64': ('linux_arm64', 'duckdb_jdbc_native_linux_arm64.jar'),
+  'linux-amd64-musl': ('linux_amd64_musl', 'duckdb_jdbc_native_linux_amd64_musl.jar'),
+  'linux-aarch64-musl': ('linux_arm64_musl', 'duckdb_jdbc_native_linux_arm64_musl.jar'),
+  'osx-universal': ('macos_universal', 'duckdb_jdbc_native_osx_universal.jar'),
+  'windows-amd64': ('windows_amd64', 'duckdb_jdbc_native_windows_amd64.jar'),
+  'windows-aarch64': ('windows_arm64', 'duckdb_jdbc_native_windows_arm64.jar'),
+}
+
+# Native classifiers included in the duckdb_jdbc aggregate (thin) POM. musl and
+# Windows ARM64 are published but not part of it; they are opt-in.
+aggregate_classifiers = ['linux_amd64', 'linux_arm64', 'macos_universal', 'windows_amd64']
 
 staging_dir = tempfile.mkdtemp()
 
-binary_jar = '%s/duckdb_jdbc-%s.jar' % (staging_dir, release_version)
-pom = '%s/duckdb_jdbc-%s.pom' % (staging_dir, release_version)
-sources_jar = '%s/duckdb_jdbc-%s-sources.jar' % (staging_dir, release_version)
-javadoc_jar = '%s/duckdb_jdbc-%s-javadoc.jar' % (staging_dir, release_version)
-nolib_jar = '%s/duckdb_jdbc-%s-nolib.jar' % (staging_dir, release_version)
+def aggregate_pom_path(version):
+  return '%s/duckdb_jdbc-%s.pom' % (staging_dir, version)
 
+# sources/javadoc are attached to the duckdb_jdbc_java artifact only
+java_jar = '%s/duckdb_jdbc_java-%s.jar' % (staging_dir, release_version)
+java_pom = '%s/duckdb_jdbc_java-%s.pom' % (staging_dir, release_version)
+sources_jar = '%s/duckdb_jdbc_java-%s-sources.jar' % (staging_dir, release_version)
+javadoc_jar = '%s/duckdb_jdbc_java-%s-javadoc.jar' % (staging_dir, release_version)
+
+# duckdb_jdbc: empty JAR (backward-compat shell) + thin aggregate POM
+aggregate_jar = '%s/duckdb_jdbc-%s.jar' % (staging_dir, release_version)
+
+# native artifacts per classifier
+classifier_poms = {}
 arch_specific_jars = []
-for i in range(len(arch_specific_builds)):
-  build = arch_specific_builds[i]
-  classifier = arch_specific_classifiers[i]
-  arch_specific_jars.append('%s/duckdb_jdbc-%s-%s.jar' % (staging_dir, release_version, classifier))
+for build, (classifier, native_jar) in arch_specific_builds.items():
+  arch_specific_jars.append('%s/duckdb_jdbc_%s-%s.jar' % (staging_dir, classifier, release_version))
+  classifier_poms[classifier] = '%s/duckdb_jdbc_%s-%s.pom' % (staging_dir, classifier, release_version)
 
-pom_template = """
-<project>
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>org.duckdb</groupId>
-  <artifactId>duckdb_jdbc</artifactId>
-  <version>${VERSION}</version>
-  <packaging>jar</packaging>
-  <name>DuckDB JDBC Driver</name>
-  <description>A JDBC-Compliant driver for the DuckDB data management system</description>
-  <url>https://www.duckdb.org</url>
+# thin aggregate POM for duckdb_jdbc (unconditional deps on the 4 core OS natives)
+pom_template = pathlib.Path(jdbc_root_path, "pom.xml.template").read_text()
+aggregate_pom = aggregate_pom_path(release_version)
+pathlib.Path(aggregate_pom).write_text(pom_template.replace("${VERSION}", release_version))
 
-  <licenses>
-    <license>
-      <name>MIT License</name>
-      <url>https://raw.githubusercontent.com/duckdb/duckdb/main/LICENSE</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
+# java artifact POM + native classifier POMs come from the shared template
+module_pom_template = pathlib.Path(jdbc_root_path, "classifier-pom.xml.template").read_text()
+def write_module_pom(pom_path, artifact_id, classifier):
+  content = module_pom_template\
+      .replace("${ARTIFACT_ID}", artifact_id)\
+      .replace("${VERSION}", release_version)\
+      .replace("${CLASSIFIER}", classifier)
+  pathlib.Path(pom_path).write_text(content)
 
-  <developers>
-      <developer>
-      <name>Mark Raasveldt</name>
-      <email>mark@duckdblabs.com</email>
-      <organization>DuckDB Labs</organization>
-      <organizationUrl>https://www.duckdblabs.com</organizationUrl>
-    </developer>
-    <developer>
-      <name>Hannes Muehleisen</name>
-      <email>hannes@duckdblabs.com</email>
-      <organization>DuckDB Labs</organization>
-      <organizationUrl>https://www.duckdblabs.com</organizationUrl>
-    </developer>
-  </developers>
+write_module_pom(java_pom, "duckdb_jdbc_java", "java")
+for classifier, classifier_pom in classifier_poms.items():
+  write_module_pom(classifier_pom, "duckdb_jdbc_%s" % classifier, classifier)
 
-  <scm>
-    <connection>scm:git:git://github.com/duckdb/duckdb.git</connection>
-    <developerConnection>scm:git:ssh://github.com:duckdb/duckdb.git</developerConnection>
-    <url>http://github.com/duckdb/duckdb/tree/main</url>
-  </scm>
+# the pure-Java JAR is taken from any platform build (they are identical now that the
+# native library lives in separate classifier JARs)
+binary_src_jar = os.path.join(jdbc_artifact_dir, "java-linux-amd64", "duckdb_jdbc.jar")
+shutil.copyfile(binary_src_jar, java_jar)
 
-</project>
-<!-- Note: this cannot be used to build the JDBC driver, we only use it to deploy -->
-"""
-
-# create a matching POM with this version
-pom_path = pathlib.Path(pom)
-pom_path.write_text(pom_template.replace("${VERSION}", release_version))
-
-# prepare 'empty' jar
-linux_amd64_src_jar = os.path.join(jdbc_artifact_dir, "java-" + combine_builds[0], "duckdb_jdbc.jar")
-with zipfile.ZipFile(linux_amd64_src_jar) as linux_amd64:
-  with zipfile.ZipFile(binary_jar, mode='w') as nolib:
-    for item in linux_amd64.infolist():
-      if item.filename != "libduckdb_java.so_linux_amd64":
-        buffer = linux_amd64.read(item.filename)
-        nolib.writestr(item, buffer)
-
-# copy 'empty' jar to '-nolib' classifier
-shutil.copyfile(binary_jar, nolib_jar)
-
-# fatten up 'empty' jar adding native libs
-for build in combine_builds:
-    old_jar = zipfile.ZipFile(os.path.join(jdbc_artifact_dir, "java-" + build, "duckdb_jdbc.jar"), 'r')
-    for zip_entry in old_jar.namelist():
-        if zip_entry.startswith('libduckdb_java.so'):
-            old_jar.extract(zip_entry, staging_dir)
-            exec("jar -uf %s -C %s %s" % (binary_jar, staging_dir, zip_entry))
+# empty JAR for the aggregate: manifest only, no classes/natives
+aggregate_manifest = os.path.join(staging_dir, "aggregate-manifest")
+pathlib.Path(aggregate_manifest).write_text(
+  "Manifest-Version: 1.0\nCreated-By: duckdb-java\n\n")
+exec("jar -cfm %s %s" % (aggregate_jar, aggregate_manifest))
 
 javadoc_stage_dir = tempfile.mkdtemp()
 
@@ -166,22 +131,23 @@ exec("javadoc -Xdoclint:-reference -d %s -sourcepath %s/src/main/java org.duckdb
 exec("jar -cvf %s -C %s ." % (javadoc_jar, javadoc_stage_dir))
 exec("jar -cvf %s -C %s/src/main/java org" % (sources_jar, jdbc_root_path))
 
-# copy arch-specific JARs
-for i in range(len(arch_specific_builds)):
-  build = arch_specific_builds[i]
-  src_jar = os.path.join(jdbc_artifact_dir, "java-" + build, "duckdb_jdbc.jar")
-  dest_jar = arch_specific_jars[i] 
+# copy each platform's native JAR to its first-class artifact name
+for build, (classifier, native_jar) in arch_specific_builds.items():
+  src_jar = os.path.join(jdbc_artifact_dir, "java-" + build, native_jar)
+  dest_jar = os.path.join(staging_dir, "duckdb_jdbc_%s-%s.jar" % (classifier, release_version))
   shutil.copyfile(src_jar, dest_jar)
 
 files_to_deploy = [
-  binary_jar,
+  aggregate_jar,
+  aggregate_pom,
+  java_jar,
+  java_pom,
   sources_jar,
   javadoc_jar,
-  nolib_jar,
-  pom
 ]
-for jar in arch_specific_jars:
+for jar, classifier_pom in zip(arch_specific_jars, classifier_poms.values()):
   files_to_deploy.append(jar)
+  files_to_deploy.append(classifier_pom)
 
 # make sure all files exist before continuing
 for file in files_to_deploy:
@@ -195,11 +161,18 @@ for file in files_to_deploy:
 bundle_root_dir = path.join(staging_dir, "central-bundle")
 bundle_zip = path.join(staging_dir, "central-bundle.zip")
 
-bundle_dir = path.join(bundle_root_dir, "org", "duckdb", "duckdb_jdbc", release_version)
-os.makedirs(bundle_dir)
+# The Central Portal bundle requires one directory per (artifact, version):
+#   org/duckdb/<artifactId>/<version>/<files>
+# Each staged file is routed to its artifact's directory by matching the known
+# artifactId prefix (the aggregate 'duckdb_jdbc', the java artifact, or each native).
+native_artifact_ids = ["duckdb_jdbc_%s" % classifier for classifier, _ in arch_specific_builds.values()]
+all_artifact_ids = ["duckdb_jdbc", "duckdb_jdbc_java"] + native_artifact_ids
 
 for file in files_to_deploy:
   file_name = path.basename(file)
+  artifact_id = next(aid for aid in all_artifact_ids if file_name.startswith(aid + "-" + release_version))
+  bundle_dir = path.join(bundle_root_dir, "org", "duckdb", artifact_id, release_version)
+  os.makedirs(bundle_dir, exist_ok=True)
   bundle_file = path.join(bundle_dir, file_name)
   shutil.copyfile(file, bundle_file)
   subprocess.run(["gpg", "--sign", "-ab", file_name], cwd=bundle_dir)

--- a/scripts/jdbc_maven_deploy_s3.py
+++ b/scripts/jdbc_maven_deploy_s3.py
@@ -14,31 +14,25 @@ import shutil
 import subprocess
 import sys
 import tempfile
-import zipfile
-import re
-import base64
 import hashlib
 from os import path
 
 script_dir = path.dirname(path.abspath(__file__))
 project_dir = path.dirname(script_dir)
 
-# Mapping of build directories to Maven classifiers.
-# These architecture-specific JARs contain native libraries for a single platform only,
-# useful for reducing deployment size when the target platform is known.
+# Per CI build directory: (Maven classifier, name of the native JAR produced by CMake).
+# Each native JAR contains the native library for a single platform (libduckdb_java.so_
+# <os>_<arch>[<libc>]) at its root. glibc and musl share the same .so name, so the libc
+# is reflected in both the CMake native JAR name and the published classifier.
 arch_builds = {
-    'java-linux-amd64': 'linux_amd64',
-    'java-linux-aarch64': 'linux_arm64',
-    'java-linux-amd64-musl': 'linux_amd64_musl',    # Alpine Linux
-    'java-linux-aarch64-musl': 'linux_arm64_musl',  # Alpine Linux ARM
-    'java-osx-universal': 'macos_universal',        # Intel + Apple Silicon
-    'java-windows-amd64': 'windows_amd64',
-    'java-windows-aarch64': 'windows_arm64',
+    'java-linux-amd64': ('linux_amd64', 'duckdb_jdbc_native_linux_amd64.jar'),
+    'java-linux-aarch64': ('linux_arm64', 'duckdb_jdbc_native_linux_arm64.jar'),
+    'java-linux-amd64-musl': ('linux_amd64_musl', 'duckdb_jdbc_native_linux_amd64_musl.jar'),    # Alpine Linux
+    'java-linux-aarch64-musl': ('linux_arm64_musl', 'duckdb_jdbc_native_linux_arm64_musl.jar'),  # Alpine Linux ARM
+    'java-osx-universal': ('macos_universal', 'duckdb_jdbc_native_osx_universal.jar'),        # Intel + Apple Silicon
+    'java-windows-amd64': ('windows_amd64', 'duckdb_jdbc_native_windows_amd64.jar'),
+    'java-windows-aarch64': ('windows_arm64', 'duckdb_jdbc_native_windows_arm64.jar'),
 }
-
-# Builds to combine into the main (fat) JAR.
-# The main JAR includes natives for all major platforms for convenience.
-combine_builds = ['java-linux-amd64', 'java-osx-universal', 'java-windows-amd64', 'java-linux-aarch64']
 
 def run_cmd(cmd, check=True, cwd=project_dir):
     """Execute a command and return output."""
@@ -60,111 +54,32 @@ def get_snapshot_version(external_version):
         prefix = prefix[1:]
     return f"{prefix}-{commit_hash}"
 
-def create_combined_jar(artifact_dir, bundle_dir, version):
-    """Create a fat JAR combining native libraries from multiple platforms."""
-    combined_jar = os.path.join(bundle_dir, f'duckdb_jdbc-{version}.jar')
-    base_jar = os.path.join(artifact_dir, 'java-linux-amd64', 'duckdb_jdbc.jar')
+def create_pom(version):
+    """Create the aggregate duckdb_jdbc (thin) POM declaring the 4 core OS natives."""
+    pom_template = pathlib.Path(project_dir, "pom.xml.template").read_text()
+    return pom_template.replace("${VERSION}", version)
 
-    with zipfile.ZipFile(combined_jar, 'w') as dst:
-        # Copy base jar excluding native libs
-        with zipfile.ZipFile(base_jar) as src:
-            for item in src.infolist():
-                if not item.filename.startswith('libduckdb_java.so'):
-                    dst.writestr(item, src.read(item.filename))
-
-        # Add native libraries from all platforms
-        for build in combine_builds:
-            build_jar = os.path.join(artifact_dir, build, 'duckdb_jdbc.jar')
-            with zipfile.ZipFile(build_jar) as src:
-                for item in src.infolist():
-                    if item.filename.startswith('libduckdb_java.so'):
-                        dst.writestr(item, src.read(item.filename))
-
-    return combined_jar
-
-def create_nolib_jar(artifact_dir, bundle_dir, version):
-    """
-    Create a JAR without native libraries (nolib classifier).
-
-    This variant contains only Java classes without any bundled native libraries.
-    Useful for:
-    - Custom native library management (loading from system path or custom location)
-    - Platforms not covered by pre-built natives (users compile their own)
-    - Smaller artifact size when natives are managed separately
-    - Container/deployment scenarios where natives are provided at infrastructure level
-    """
-    nolib_jar = os.path.join(bundle_dir, f'duckdb_jdbc-{version}-nolib.jar')
-    base_jar = os.path.join(artifact_dir, 'java-linux-amd64', 'duckdb_jdbc.jar')
-
-    with zipfile.ZipFile(base_jar) as src:
-        with zipfile.ZipFile(nolib_jar, 'w') as dst:
-            for item in src.infolist():
-                if not item.filename.startswith('libduckdb_java.so'):
-                    dst.writestr(item, src.read(item.filename))
-
-    return nolib_jar
-
-def create_pom(bundle_dir, version):
-    """Create POM file for the artifact."""
-    pom_content = f"""<?xml version="1.0" encoding="UTF-8"?>
-<project>
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>org.duckdb</groupId>
-  <artifactId>duckdb_jdbc</artifactId>
-  <version>{version}</version>
-  <packaging>jar</packaging>
-  <name>DuckDB JDBC Driver</name>
-  <description>A JDBC-Compliant driver for the DuckDB data management system</description>
-  <url>https://www.duckdb.org</url>
-
-  <licenses>
-    <license>
-      <name>MIT License</name>
-      <url>https://raw.githubusercontent.com/duckdb/duckdb/main/LICENSE</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
-
-  <developers>
-    <developer>
-      <name>Mark Raasveldt</name>
-      <email>mark@duckdblabs.com</email>
-      <organization>DuckDB Labs</organization>
-      <organizationUrl>https://www.duckdblabs.com</organizationUrl>
-    </developer>
-    <developer>
-      <name>Hannes Muehleisen</name>
-      <email>hannes@duckdblabs.com</email>
-      <organization>DuckDB Labs</organization>
-      <organizationUrl>https://www.duckdblabs.com</organizationUrl>
-    </developer>
-  </developers>
-
-  <scm>
-    <connection>scm:git:git://github.com/duckdb/duckdb-java.git</connection>
-    <developerConnection>scm:git:ssh://github.com:duckdb/duckdb-java.git</developerConnection>
-    <url>https://github.com/duckdb/duckdb-java</url>
-  </scm>
-</project>
-"""
-    pom_path = os.path.join(bundle_dir, f'duckdb_jdbc-{version}.pom')
-    pathlib.Path(pom_path).write_text(pom_content)
-    return pom_path
-
+def create_module_pom(version, artifact_id, classifier):
+    """Create the minimal POM for a first-class module artifact (java or native)."""
+    module_template = pathlib.Path(project_dir, "classifier-pom.xml.template").read_text()
+    return module_template\
+        .replace("${ARTIFACT_ID}", artifact_id)\
+        .replace("${VERSION}", version)\
+        .replace("${CLASSIFIER}", classifier)
 
 def create_sources_jar(jdbc_root, bundle_dir, version):
-    """Create sources JAR."""
-    sources_jar = os.path.join(bundle_dir, f'duckdb_jdbc-{version}-sources.jar')
+    """Create sources JAR (attached to duckdb_jdbc_java)."""
+    sources_jar = os.path.join(bundle_dir, f'duckdb_jdbc_java-{version}-sources.jar')
     run_cmd(f'jar -cvf {sources_jar} -C {jdbc_root}/src/main/java org')
     return sources_jar
 
 
 def create_javadoc_jar(jdbc_root, bundle_dir, version):
-    """Create javadoc JAR."""
+    """Create javadoc JAR (attached to duckdb_jdbc_java)."""
     javadoc_dir = tempfile.mkdtemp()
     try:
         run_cmd(f'javadoc -Xdoclint:-reference -d {javadoc_dir} -sourcepath {jdbc_root}/src/main/java org.duckdb')
-        javadoc_jar = os.path.join(bundle_dir, f'duckdb_jdbc-{version}-javadoc.jar')
+        javadoc_jar = os.path.join(bundle_dir, f'duckdb_jdbc_java-{version}-javadoc.jar')
         run_cmd(f'jar -cvf {javadoc_jar} -C {javadoc_dir} .')
         return javadoc_jar
     finally:
@@ -191,42 +106,53 @@ print(f"Deploying SNAPSHOT version: {version}")
 
 staging_dir = tempfile.mkdtemp()
 
-bundle_dir = path.join(staging_dir, version)
-os.mkdir(bundle_dir)
+# bundle is laid out as the Maven repo it will be uploaded to:
+#   org/duckdb/<artifactId>/<version>/<files>
+maven_root = path.join(staging_dir, "org", "duckdb")
+def artifact_dir_for(artifact_id):
+    return path.join(maven_root, artifact_id, version)
 
-pom = create_pom(bundle_dir, version)
-combined_jar = create_combined_jar(artifact_dir, bundle_dir, version)
-sources_jar = create_sources_jar(project_dir, bundle_dir, version)
-javadoc_jar = create_javadoc_jar(project_dir, bundle_dir, version)
-nolib_jar = create_nolib_jar(artifact_dir, bundle_dir, version)
-arch_specific_jars = []
+# aggregate: empty JAR (backward-compat shell) + thin POM
+aggregate_dir = artifact_dir_for("duckdb_jdbc")
+os.makedirs(aggregate_dir)
+aggregate_jar = path.join(aggregate_dir, f'duckdb_jdbc-{version}.jar')
+aggregate_manifest = os.path.join(staging_dir, "aggregate-manifest")
+pathlib.Path(aggregate_manifest).write_text("Manifest-Version: 1.0\nCreated-By: duckdb-java\n\n")
+run_cmd(f"jar -cfm {aggregate_jar} {aggregate_manifest}")
+pathlib.Path(aggregate_dir, f'duckdb_jdbc-{version}.pom').write_text(create_pom(version))
 
-for build_name, classifier in arch_builds.items():
-    src_jar = path.join(artifact_dir, build_name, 'duckdb_jdbc.jar')
-    dest_jar = path.join(bundle_dir, f'duckdb_jdbc-{version}-{classifier}.jar')
-    shutil.copyfile(src_jar, dest_jar)
-    arch_specific_jars.append(dest_jar)
+# java artifact: classes + sources + javadoc + minimal POM
+java_dir = artifact_dir_for("duckdb_jdbc_java")
+os.makedirs(java_dir)
+run_cmd(f'cp {path.join(artifact_dir, "java-linux-amd64", "duckdb_jdbc.jar")} {path.join(java_dir, f"duckdb_jdbc_java-{version}.jar")}')
+pathlib.Path(java_dir, f'duckdb_jdbc_java-{version}.pom').write_text(create_module_pom(version, "duckdb_jdbc_java", "java"))
+create_sources_jar(project_dir, java_dir, version)
+create_javadoc_jar(project_dir, java_dir, version)
 
-files_to_deploy = [
-  combined_jar,
-  sources_jar,
-  javadoc_jar,
-  nolib_jar,
-  pom
-]
-for jar in arch_specific_jars:
-  files_to_deploy.append(jar)
+# native artifacts: one first-class GAV per classifier
+for build_name, (classifier, native_jar) in arch_builds.items():
+    native_dir = artifact_dir_for("duckdb_jdbc_%s" % classifier)
+    os.makedirs(native_dir)
+    run_cmd(f'cp {path.join(artifact_dir, build_name, native_jar)} {path.join(native_dir, f"duckdb_jdbc_{classifier}-{version}.jar")}')
+    pathlib.Path(native_dir, f'duckdb_jdbc_{classifier}-{version}.pom').write_text(
+        create_module_pom(version, "duckdb_jdbc_%s" % classifier, classifier))
+
+files_to_deploy = []
+for root, dirs, files in os.walk(maven_root):
+    for f in files:
+        files_to_deploy.append(os.path.join(root, f))
 
 # make sure all files exist before continuing
 for file in files_to_deploy:
   if not path.isfile(file):
     raise ValueError(f"Could not create all required files: {file}")
 
-# now sign all files 
+# now sign all files
 
 for file in files_to_deploy:
+  file_dir = path.dirname(file)
   file_name = path.basename(file)
-  run_cmd(f"gpg --sign -ab {file_name}", cwd=bundle_dir)
+  run_cmd(f"gpg --sign -ab {file_name}", cwd=file_dir)
   with open(file, "rb") as fd:
     file_bytes = fd.read()
   for alg in ["md5", "sha1", "sha256"]:
@@ -235,7 +161,7 @@ for file in files_to_deploy:
     hashsum = digest.hexdigest()
     with open(f"{file}.{alg}", "w") as fd:
       fd.write(hashsum)
-subprocess.run(["ls", "-laR", bundle_dir])
+subprocess.run(["find", maven_root, "-type", "f"])
 
 # upload files to s3
 
@@ -245,7 +171,8 @@ if not ("AWS_ENDPOINT_URL" in os.environ and
         "AWS_SECRET_ACCESS_KEY" in os.environ):
   dry_run = "--dryrun"
 
-run_cmd(f"aws s3 cp {bundle_dir} s3://duckdb-staging/duckdb/duckdb-java/maven/org/duckdb/duckdb_jdbc/{version}/ {dry_run} --recursive", cwd=staging_dir)
+# upload the org/duckdb/... tree to the maven repository root
+run_cmd(f"aws s3 cp {maven_root} s3://duckdb-staging/duckdb/duckdb-java/maven/org/duckdb/ {dry_run} --recursive", cwd=staging_dir)
 
 print(f"""
 <dependency>


### PR DESCRIPTION
it makes it fatty and bothering when creating distribution or docker images, also makes creating fatjars/shades quite slow for nothing

design: duckdb_jdbc = empty jar (for compatibility of pom but the jar is technically useless) with as dependency (pom) java lib + 4 historical native lib, duckdb_jdbc_java = java code, then one jar per native lib

note: review of release process is welcomed, I'm not 100% sure what I did is aligned on the practise