### PR TITLE
Fix primitive nullability in ArrayResultSet (1.5)

### DIFF
--- a/src/main/java/org/duckdb/DuckDBArrayResultSet.java
+++ b/src/main/java/org/duckdb/DuckDBArrayResultSet.java
@@ -49,9 +49,14 @@ public class DuckDBArrayResultSet implements ResultSet {
         if (columnIndex != 2) {
             throw new SQLException("Array-backed ResultSet can only have two columns");
         }
-        T value = getter.getValue(offset + currentValueIndex);
 
-        wasNull = value == null;
+        int idx = offset + currentValueIndex;
+        this.wasNull = vector.isNull(idx);
+        T value = getter.getValue(idx);
+
+        if (value == null) {
+            this.wasNull = true;
+        }
         return value;
     }
 

--- a/src/main/java/org/duckdb/DuckDBResultSet.java
+++ b/src/main/java/org/duckdb/DuckDBResultSet.java
@@ -180,7 +180,7 @@ public class DuckDBResultSet implements ResultSet {
     private boolean checkAndNull(int columnIndex) throws SQLException {
         check(columnIndex);
         try {
-            wasNull = currentChunk[columnIndex - 1].check_and_null(chunkIdx - 1);
+            wasNull = currentChunk[columnIndex - 1].isNull(chunkIdx - 1);
         } catch (ArrayIndexOutOfBoundsException e) {
             throw new SQLException("No row in context", e);
         }

--- a/src/main/java/org/duckdb/DuckDBVector.java
+++ b/src/main/java/org/duckdb/DuckDBVector.java
@@ -68,7 +68,7 @@ class DuckDBVector {
     }
 
     Object getObject(int idx) throws SQLException {
-        if (check_and_null(idx)) {
+        if (isNull(idx)) {
             return null;
         }
         switch (duckdb_type) {
@@ -138,7 +138,7 @@ class DuckDBVector {
     }
 
     LocalTime getLocalTime(int idx) throws SQLException {
-        if (check_and_null(idx)) {
+        if (isNull(idx)) {
             return null;
         }
 
@@ -170,7 +170,7 @@ class DuckDBVector {
     }
 
     LocalDate getLocalDate(int idx) throws SQLException {
-        if (check_and_null(idx)) {
+        if (isNull(idx)) {
             return null;
         }
 
@@ -203,7 +203,7 @@ class DuckDBVector {
     }
 
     BigDecimal getBigDecimal(int idx) throws SQLException {
-        if (check_and_null(idx)) {
+        if (isNull(idx)) {
             return null;
         }
         if (isType(DuckDBColumnType.DECIMAL)) {
@@ -229,7 +229,7 @@ class DuckDBVector {
     }
 
     OffsetDateTime getOffsetDateTime(int idx) throws SQLException {
-        if (check_and_null(idx)) {
+        if (isNull(idx)) {
             return null;
         }
 
@@ -259,7 +259,7 @@ class DuckDBVector {
     }
 
     UUID getUuid(int idx) throws SQLException {
-        if (check_and_null(idx)) {
+        if (isNull(idx)) {
             return null;
         }
 
@@ -277,14 +277,14 @@ class DuckDBVector {
     }
 
     String getLazyString(int idx) {
-        if (check_and_null(idx)) {
+        if (isNull(idx)) {
             return null;
         }
         return varlen_data[idx].toString();
     }
 
     Array getArray(int idx) throws SQLException {
-        if (check_and_null(idx)) {
+        if (isNull(idx)) {
             return null;
         }
         if (isType(DuckDBColumnType.LIST) || isType(DuckDBColumnType.ARRAY)) {
@@ -294,7 +294,7 @@ class DuckDBVector {
     }
 
     Map<Object, Object> getMap(int idx) throws SQLException {
-        if (check_and_null(idx)) {
+        if (isNull(idx)) {
             return null;
         }
         if (!isType(DuckDBColumnType.MAP)) {
@@ -313,7 +313,7 @@ class DuckDBVector {
     }
 
     Blob getBlob(int idx) throws SQLException {
-        if (check_and_null(idx)) {
+        if (isNull(idx)) {
             return null;
         }
         if (isType(DuckDBColumnType.BLOB) || isType(DuckDBColumnType.GEOMETRY)) {
@@ -324,7 +324,7 @@ class DuckDBVector {
     }
 
     byte[] getBytes(int idx) throws SQLException {
-        if (check_and_null(idx)) {
+        if (isNull(idx)) {
             return null;
         }
 
@@ -336,7 +336,7 @@ class DuckDBVector {
     }
 
     JsonNode getJsonObject(int idx) {
-        if (check_and_null(idx)) {
+        if (isNull(idx)) {
             return null;
         }
         String result = getLazyString(idx);
@@ -344,7 +344,7 @@ class DuckDBVector {
     }
 
     Date getDate(int idx) throws SQLException {
-        if (check_and_null(idx)) {
+        if (isNull(idx)) {
             return null;
         }
 
@@ -371,7 +371,7 @@ class DuckDBVector {
     }
 
     OffsetTime getOffsetTime(int idx) throws SQLException {
-        if (check_and_null(idx)) {
+        if (isNull(idx)) {
             return null;
         }
 
@@ -407,7 +407,7 @@ class DuckDBVector {
     }
 
     Time getTime(int idx, Calendar cal) throws SQLException {
-        if (check_and_null(idx)) {
+        if (isNull(idx)) {
             return null;
         }
 
@@ -441,7 +441,7 @@ class DuckDBVector {
     }
 
     Boolean getBoolean(int idx) throws SQLException {
-        if (check_and_null(idx)) {
+        if (isNull(idx)) {
             return false;
         }
         if (isType(DuckDBColumnType.BOOLEAN)) {
@@ -467,12 +467,12 @@ class DuckDBVector {
         return buf.getLong();
     }
 
-    protected boolean check_and_null(int idx) {
+    boolean isNull(int idx) {
         return nullmask[idx];
     }
 
     long getLong(int idx) throws SQLException {
-        if (check_and_null(idx)) {
+        if (isNull(idx)) {
             return 0;
         }
         if (isType(DuckDBColumnType.BIGINT) || isType(DuckDBColumnType.TIMESTAMP) ||
@@ -487,7 +487,7 @@ class DuckDBVector {
     }
 
     int getInt(int idx) throws SQLException {
-        if (check_and_null(idx)) {
+        if (isNull(idx)) {
             return 0;
         }
         if (isType(DuckDBColumnType.INTEGER)) {
@@ -501,7 +501,7 @@ class DuckDBVector {
     }
 
     short getUint8(int idx) throws SQLException {
-        if (check_and_null(idx)) {
+        if (isNull(idx)) {
             return 0;
         }
         if (isType(DuckDBColumnType.UTINYINT)) {
@@ -511,7 +511,7 @@ class DuckDBVector {
     }
 
     long getUint32(int idx) throws SQLException {
-        if (check_and_null(idx)) {
+        if (isNull(idx)) {
             return 0;
         }
         if (isType(DuckDBColumnType.UINTEGER)) {
@@ -521,7 +521,7 @@ class DuckDBVector {
     }
 
     int getUint16(int idx) throws SQLException {
-        if (check_and_null(idx)) {
+        if (isNull(idx)) {
             return 0;
         }
         if (isType(DuckDBColumnType.USMALLINT)) {
@@ -531,7 +531,7 @@ class DuckDBVector {
     }
 
     BigInteger getUint64(int idx) throws SQLException {
-        if (check_and_null(idx)) {
+        if (isNull(idx)) {
             return BigInteger.ZERO;
         }
         if (isType(DuckDBColumnType.UBIGINT)) {
@@ -544,7 +544,7 @@ class DuckDBVector {
     }
 
     double getDouble(int idx) throws SQLException {
-        if (check_and_null(idx)) {
+        if (isNull(idx)) {
             return Double.NaN;
         }
         if (isType(DuckDBColumnType.DOUBLE)) {
@@ -558,7 +558,7 @@ class DuckDBVector {
     }
 
     byte getByte(int idx) throws SQLException {
-        if (check_and_null(idx)) {
+        if (isNull(idx)) {
             return 0;
         }
         if (isType(DuckDBColumnType.TINYINT)) {
@@ -572,7 +572,7 @@ class DuckDBVector {
     }
 
     short getShort(int idx) throws SQLException {
-        if (check_and_null(idx)) {
+        if (isNull(idx)) {
             return 0;
         }
         if (isType(DuckDBColumnType.SMALLINT)) {
@@ -586,7 +586,7 @@ class DuckDBVector {
     }
 
     BigInteger getHugeint(int idx) throws SQLException {
-        if (check_and_null(idx)) {
+        if (isNull(idx)) {
             return BigInteger.ZERO;
         }
         if (isType(DuckDBColumnType.HUGEINT)) {
@@ -602,7 +602,7 @@ class DuckDBVector {
     }
 
     BigInteger getUhugeint(int idx) throws SQLException {
-        if (check_and_null(idx)) {
+        if (isNull(idx)) {
             return BigInteger.ZERO;
         }
         if (isType(DuckDBColumnType.UHUGEINT)) {
@@ -618,7 +618,7 @@ class DuckDBVector {
     }
 
     float getFloat(int idx) throws SQLException {
-        if (check_and_null(idx)) {
+        if (isNull(idx)) {
             return Float.NaN;
         }
         if (isType(DuckDBColumnType.FLOAT)) {
@@ -644,7 +644,7 @@ class DuckDBVector {
     }
 
     Timestamp getTimestamp(int idx, Calendar calNullable) throws SQLException {
-        if (check_and_null(idx)) {
+        if (isNull(idx)) {
             return null;
         }
         final LocalDateTime ldt;
@@ -681,7 +681,7 @@ class DuckDBVector {
     }
 
     private LocalDateTime getLocalDateTimeFromTimestamp(int idx, Calendar calNullable) throws SQLException {
-        if (check_and_null(idx)) {
+        if (isNull(idx)) {
             return null;
         }
         ZoneId zoneIdNullable = calNullable != null ? calNullable.getTimeZone().toZoneId() : null;
@@ -702,11 +702,11 @@ class DuckDBVector {
     }
 
     Struct getStruct(int idx) {
-        return check_and_null(idx) ? null : (Struct) varlen_data[idx];
+        return isNull(idx) ? null : (Struct) varlen_data[idx];
     }
 
     Object getUnion(int idx) throws SQLException {
-        if (check_and_null(idx))
+        if (isNull(idx))
             return null;
 
         Struct struct = getStruct(idx);

--- a/src/test/java/org/duckdb/TestDuckDBJDBC.java
+++ b/src/test/java/org/duckdb/TestDuckDBJDBC.java
@@ -1,5 +1,6 @@
 package org.duckdb;
 
+import static java.lang.Float.NaN;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
@@ -1246,7 +1247,7 @@ public class TestDuckDBJDBC {
     public static void test_array_resultset() throws Exception {
         try (Connection connection = DriverManager.getConnection(JDBC_URL);
              Statement statement = connection.createStatement()) {
-            try (ResultSet rs = statement.executeQuery("select [42, 69]")) {
+            try (ResultSet rs = statement.executeQuery("select [42, 69, NULL]")) {
                 assertTrue(rs.next());
                 ResultSet arrayResultSet = rs.getArray(1).getResultSet();
                 assertTrue(arrayResultSet.next());
@@ -1265,6 +1266,23 @@ public class TestDuckDBJDBC {
                 assertTrue(arrayResultSet.next());
                 assertEquals(arrayResultSet.getInt(1), 2);
                 assertEquals(arrayResultSet.getInt(2), 69);
+                assertFalse(arrayResultSet.wasNull());
+                assertTrue(arrayResultSet.next());
+                assertEquals(arrayResultSet.getInt(1), 3);
+                assertEquals(arrayResultSet.getInt(2), 0);
+                assertTrue(arrayResultSet.wasNull());
+                assertEquals(arrayResultSet.getByte(2), (byte) 0);
+                assertTrue(arrayResultSet.wasNull());
+                assertEquals(arrayResultSet.getShort(2), (short) 0);
+                assertTrue(arrayResultSet.wasNull());
+                assertEquals(arrayResultSet.getLong(2), (long) 0);
+                assertTrue(arrayResultSet.wasNull());
+                assertEquals(arrayResultSet.getFloat(2), NaN);
+                assertTrue(arrayResultSet.wasNull());
+                assertEquals(arrayResultSet.getDouble(2), (double) NaN);
+                assertTrue(arrayResultSet.wasNull());
+                assertEquals(arrayResultSet.getBigDecimal(2), null);
+                assertTrue(arrayResultSet.wasNull());
                 assertFalse(arrayResultSet.next());
             }
 


### PR DESCRIPTION
This is a backport of the PR #839 to `v1.5.5` stable branch.

Fixes: #833