### PR TITLE
Add Graal CI job

### DIFF
--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -165,6 +165,51 @@ jobs:
             make -C /duckdb/jdbc_compatibility_test_suite_runner test
           "
 
+  java-linux-amd64-graal:
+    name: Linux GraalVM Native Image (amd64)
+    runs-on: ubuntu-latest
+    needs: java-linux-amd64
+    env:
+      MANYLINUX_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
+      DUCKDB_JDBC_JAR: ${{ github.workspace }}/build/release/duckdb_jdbc.jar
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Cache Key
+        id: cache_key
+        run: |
+          DUCKDB_VERSION=$(python ./scripts/print_duckdb_version.py)
+          KEY="${{ runner.os }}-${{ runner.arch }}-$DUCKDB_VERSION"
+          echo "value=${KEY}" >> "${GITHUB_OUTPUT}"
+
+      - name: Restore Cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ${{ github.workspace }}/ccache
+          key: ${{ steps.cache_key.outputs.value }}
+
+      - name: Build
+        if: ${{ inputs.skip_tests != 'true' }}
+        uses: ./.github/composite-actions/linux-build-docker
+        with:
+          docker_image: '${{ env.MANYLINUX_IMAGE }}'
+
+      - name: Set up GraalVM
+        if: ${{ inputs.skip_tests != 'true' }}
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: '25'
+          distribution: 'graalvm-community'
+
+      - name: Native Image Hello World
+        if: ${{ inputs.skip_tests != 'true' }}
+        run: |
+          java ${{ github.workspace }}/src/test/external/RunGraalNativeImage.java \
+            ${{ github.workspace }}/src/test/external/graal
+
+
   java-linux-amd64-spark:
     name: Linux Spark (amd64)
     runs-on: ubuntu-latest
@@ -844,6 +889,7 @@ jobs:
     needs:
       - java-linux-amd64
       - java-linux-amd64-tck
+      - java-linux-amd64-graal
       - java-linux-amd64-spark
       - java-linux-amd64-asan
       - java-linux-amd64-jepsen
@@ -924,6 +970,7 @@ jobs:
     needs:
       - java-linux-amd64
       - java-linux-amd64-tck
+      - java-linux-amd64-graal
       - java-linux-amd64-spark
       - java-linux-amd64-asan
       - java-linux-amd64-jepsen
@@ -997,6 +1044,7 @@ jobs:
     needs:
       - java-linux-amd64
       - java-linux-amd64-tck
+      - java-linux-amd64-graal
       - java-linux-amd64-spark
       - java-linux-amd64-asan
       - java-linux-amd64-jepsen

--- a/src/test/external/RunGraalNativeImage.java
+++ b/src/test/external/RunGraalNativeImage.java
@@ -1,0 +1,62 @@
+import static java.lang.ProcessBuilder.Redirect.INHERIT;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+
+public class RunGraalNativeImage {
+
+    static final String DUCKDB_JDBC_JAR = fromEnv("DUCKDB_JDBC_JAR", "./build/release/duckdb_jdbc.jar");
+
+    public static void main(String[] args) throws Exception {
+        if (args.length != 1) {
+            throw new RuntimeException("Path to the Graal sample directory must be specified as the only argument");
+        }
+        Path srcDir = Paths.get(args[0]);
+        Path jar = Paths.get(DUCKDB_JDBC_JAR).toAbsolutePath();
+
+        Path workDir = Paths.get("graal-hello").toAbsolutePath();
+        Path configDir = workDir.resolve("config");
+        Files.createDirectories(configDir);
+        Files.copy(srcDir.resolve("Hello.java"), workDir.resolve("Hello.java"), StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(srcDir.resolve("resource-config.json"), configDir.resolve("resource-config.json"),
+                   StandardCopyOption.REPLACE_EXISTING);
+
+        run(workDir, "javac", "-cp", jar.toString(), "Hello.java");
+        run(workDir, "native-image", "--no-fallback", "--enable-native-access=ALL-UNNAMED", "-cp",
+            jar + File.pathSeparator + ".", "-H:ConfigurationFileDirectories=config", "-o", "hello", "Hello");
+
+        Process ps = new ProcessBuilder(workDir.resolve("hello").toString())
+                         .directory(workDir.toFile())
+                         .redirectError(INHERIT)
+                         .start();
+        String output = new String(ps.getInputStream().readAllBytes(), UTF_8).trim();
+        int status = ps.waitFor();
+        System.out.println(output);
+        if (status != 0) {
+            throw new RuntimeException("Native image run failed, status: " + status);
+        }
+        if (!"42".equals(output)) {
+            throw new RuntimeException("Native image output check failed, expected: 42, actual: " + output);
+        }
+        System.out.println("Success");
+    }
+
+    static void run(Path workDir, String... command) throws Exception {
+        int status = new ProcessBuilder(command).directory(workDir.toFile()).inheritIO().start().waitFor();
+        if (status != 0) {
+            throw new RuntimeException("Command failed, status: " + status + ", command: " + String.join(" ", command));
+        }
+    }
+
+    static String fromEnv(String envVarName, String defaultValue) {
+        String env = System.getenv(envVarName);
+        if (null != env) {
+            return env;
+        }
+        return defaultValue;
+    }
+}

--- a/src/test/external/graal/Hello.java
+++ b/src/test/external/graal/Hello.java
@@ -1,0 +1,13 @@
+import java.sql.*;
+
+public class Hello {
+    public static void main(String[] a) throws Exception {
+        Class.forName("org.duckdb.DuckDBDriver");
+        try (Connection c = DriverManager.getConnection("jdbc:duckdb:"); Statement s = c.createStatement();
+             ResultSet r = s.executeQuery("SELECT 42 AS answer")) {
+            while (r.next()) {
+                System.out.println(r.getInt(1));
+            }
+        }
+    }
+}

--- a/src/test/external/graal/resource-config.json
+++ b/src/test/external/graal/resource-config.json
@@ -1,0 +1,1 @@
+{ "resources": { "includes": [ { "pattern": "libduckdb_java\\.so_linux_amd64" } ] } }


### PR DESCRIPTION
This pull request adds support for building and testing the DuckDB JDBC driver as a GraalVM native image on Linux (amd64) within the CI workflow. The main changes include introducing a new GitHub Actions job for GraalVM native image builds, updating job dependencies to include this new job, and ensuring the necessary metadata for native image generation is included in the JDBC jar.

**CI/CD Pipeline Enhancements:**

* Added a new job `java-linux-amd64-graal-native` to `.github/workflows/Java.yml` that builds and tests the JDBC driver using GraalVM Native Image. This job sets up GraalVM, compiles a sample Java program using the JDBC driver, builds a native image, and verifies basic JDBC functionality.
* Updated downstream jobs (`java-linux-amd64-all`, `java-linux-amd64-all-tck`, `java-linux-amd64-all-spark`) to depend on the new GraalVM native image job, ensuring native image builds are validated as part of the CI pipeline. [[1]](diffhunk://#diff-bdee261ab427fca8a87834d14e7706a57244a4959edd41839a00799608932571R913) [[2]](diffhunk://#diff-bdee261ab427fca8a87834d14e7706a57244a4959edd41839a00799608932571R994) [[3]](diffhunk://#diff-bdee261ab427fca8a87834d14e7706a57244a4959edd41839a00799608932571R1068)

**Build System Updates:**

* Modified `CMakeLists.txt` to include `META-INF/native-image/org.duckdb/duckdb_jdbc/reachability-metadata.json` in the JDBC jar, providing necessary metadata for GraalVM native image builds.