### PR TITLE
Register DuckDBTimestampTZ.getMicrosEpoch for JNI

### DIFF
--- a/META-INF/native-image/org.duckdb/duckdb_jdbc/reachability-metadata.json
+++ b/META-INF/native-image/org.duckdb/duckdb_jdbc/reachability-metadata.json
@@ -479,7 +479,13 @@
     },
     {
       "type": "org.duckdb.DuckDBTimestampTZ",
-      "jniAccessible": true
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "getMicrosEpoch",
+          "parameterTypes": []
+        }
+      ]
     },
     {
       "type": "org.duckdb.DuckDBVector",

--- a/src/test/external/graal/Hello.java
+++ b/src/test/external/graal/Hello.java
@@ -1,13 +1,30 @@
 import java.sql.*;
 
 public class Hello {
-    public static void main(String[] a) throws Exception {
-        Class.forName("org.duckdb.DuckDBDriver");
-        try (Connection c = DriverManager.getConnection("jdbc:duckdb:"); Statement s = c.createStatement();
-             ResultSet r = s.executeQuery("SELECT 42 AS answer")) {
-            while (r.next()) {
-                System.out.println(r.getInt(1));
+    public static void main(String[] a) {
+        try {
+            Class.forName("org.duckdb.DuckDBDriver");
+            try (Connection c = DriverManager.getConnection("jdbc:duckdb:"); Statement s = c.createStatement();
+                 ResultSet r = s.executeQuery("SELECT 42 AS answer")) {
+                while (r.next()) {
+                    System.out.println(r.getInt(1));
+                }
             }
+        } catch (Throwable t) {
+            // The default uncaught exception handler can fail to print in a native image,
+            // masking the real cause, so report it explicitly here.
+            for (Throwable e = t; e != null; e = e.getCause()) {
+                System.out.println((e == t ? "ERROR: " : "Caused by: ") + e.getClass().getName());
+                try {
+                    System.out.println("  message: " + e.getMessage());
+                    for (StackTraceElement el : e.getStackTrace()) {
+                        System.out.println("  at " + el);
+                    }
+                } catch (Throwable ignored) {
+                    System.out.println("  (could not print message/stack trace: " + ignored.getClass().getName() + ")");
+                }
+            }
+            System.exit(1);
         }
     }
 }


### PR DESCRIPTION
create_refs() looks up getMicrosEpoch via GetMethodID on the DuckDBTimestampTZ class during JNI_OnLoad, but the method is declared in its superclass DuckDBTimestamp. 

On HotSpot GetMethodID resolves inherited methods, so this works, but in a GraalVM native image the method must be registered on the queried class, so the lookup returned null, aborting JNI_OnLoad and preventing the driver from loading.

Register getMicrosEpoch on DuckDBTimestampTZ in the reachability metadata, and make the Graal native-image test's sample print the real exception, since the default uncaught exception handler can otherwise mask the cause in a native image.
