### PR TITLE
Preserve native-image reachability metadata across vendoring

### DIFF
--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -94,6 +94,7 @@ file(GLOB_RECURSE JAVA_TEST_FILES src/test/java/org/duckdb/*.java)
 set(CMAKE_JAVA_COMPILE_FLAGS -encoding utf-8 -g -Xlint:all)
 
 add_jar(duckdb_jdbc_nolib ${JAVA_SRC_FILES} META-INF/services/java.sql.Driver
+        META-INF/native-image/org.duckdb/duckdb_jdbc/reachability-metadata.json
         MANIFEST META-INF/MANIFEST.MF
         GENERATE_NATIVE_HEADERS duckdb-native)
 add_jar(duckdb_jdbc_tests ${JAVA_TEST_FILES} INCLUDE_JARS duckdb_jdbc_nolib)


### PR DESCRIPTION
The reachability-metadata.json JAR entry was added directly to the generated CMakeLists.txt but not to the CMakeLists.txt.in template. 

When the Vendor workflow regenerates CMakeLists.txt via vendor.py, the entry is dropped, so the driver JAR no longer bundles the GraalVM native-image metadata and the native-image build fails on the vendoring branch. 

This pr mirrors the entry into the template so it survives re-vendoring.