### PR TITLE
Disable jemalloc on Linux musl, add CI checks (1.5)

### DIFF
--- a/.github/workflows/Java.yml
+++ b/.github/workflows/Java.yml
@@ -70,6 +70,10 @@ jobs:
         run: |
           nm -gU ./build/release/libduckdb_java.so_linux_amd64
 
+      - name: Check jemalloc
+        run: |
+          nm ./build/release/libduckdb_java.so_linux_amd64 | grep jemalloc || exit 1
+
       - name: Check Module Name
         run: |
           java \
@@ -482,6 +486,10 @@ jobs:
         run: |
           nm -gU ./build/release/libduckdb_java.so_linux_arm64
 
+      - name: Check jemalloc
+        run: |
+          nm ./build/release/libduckdb_java.so_linux_arm64 | grep jemalloc || exit 1
+
       - name: JDBC Tests EL8
         if: ${{ inputs.skip_tests != 'true' }}
         uses: ./.github/composite-actions/linux-tests-docker
@@ -537,6 +545,10 @@ jobs:
         run: |
           nm -gU ./build/release/libduckdb_java.so_linux_amd64
 
+      - name: Check jemalloc
+        run: |
+          ! (nm ./build/release/libduckdb_java.so_linux_amd64 | grep jemalloc) || exit 1
+
       - name: JDBC Tests
         if: ${{ inputs.skip_tests != 'true' }}
         uses: ./.github/composite-actions/linux-tests-musl-docker
@@ -587,6 +599,10 @@ jobs:
       - name: List Symbols
         run: |
           nm -gU ./build/release/libduckdb_java.so_linux_arm64
+
+      - name: Check jemalloc
+        run: |
+          ! (nm ./build/release/libduckdb_java.so_linux_arm64 | grep jemalloc) || exit 1
 
       - name: JDBC Tests
         if: ${{ inputs.skip_tests != 'true' }}
@@ -799,14 +815,18 @@ jobs:
         run: |
           nm -gU ./build/release/libduckdb_java.so_osx_universal
 
-      - name: Java Tests
-        if: ${{ inputs.skip_tests != 'true' }}
-        shell: bash
-        run: make test
+      - name: Check jemalloc
+        run: |
+          ! (nm ./build/release/libduckdb_java.so_osx_universal | grep jemalloc) || exit 1
 
       - name: See if this actually universal
         shell: bash
         run: lipo -archs build/release/libduckdb_java.so_osx_universal | grep "x86_64 arm64"
+
+      - name: Java Tests
+        if: ${{ inputs.skip_tests != 'true' }}
+        shell: bash
+        run: make test
 
       - uses: actions/upload-artifact@v4
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -557,6 +557,17 @@ if(WIN32)
 endif()
 if(UNIX AND NOT APPLE)
   set(OS_NAME "linux") # sorry BSD
+  set(LINUX_MUSL FALSE)
+  execute_process(
+    COMMAND gcc -dumpmachine
+    OUTPUT_VARIABLE TARGET_TRIPLE
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  message (STATUS "Compiler target: ${TARGET_TRIPLE}")
+  if(TARGET_TRIPLE MATCHES "-musl")
+    set(LINUX_MUSL TRUE)
+    message(STATUS "Using Linux musl libc")
+  endif()
 endif()
 
 if(OVERRIDE_JDBC_OS_NAME)
@@ -582,9 +593,9 @@ add_jar(duckdb_jdbc_tests ${JAVA_TEST_FILES} INCLUDE_JARS duckdb_jdbc_nolib)
 
 # main shared lib compilation
 
-# Match ENABLE_JEMALLOC in duckdb/duckdb: 64-bit Linux only. On macOS jemalloc's src/zone.c
+# Match ENABLE_JEMALLOC in duckdb/duckdb: 64-bit glibc Linux only. On macOS jemalloc's src/zone.c
 # registers a malloc zone at dlopen time, aborting threads that free during the update.
-if(MSVC OR ZOS OR APPLE)
+if(MSVC OR ZOS OR APPLE OR LINUX_MUSL)
   set(JEMALLOC_ENABLED FALSE)
 else()
   set(JEMALLOC_ENABLED TRUE)

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -76,6 +76,17 @@ if(WIN32)
 endif()
 if(UNIX AND NOT APPLE)
   set(OS_NAME "linux") # sorry BSD
+  set(LINUX_MUSL FALSE)
+  execute_process(
+    COMMAND gcc -dumpmachine
+    OUTPUT_VARIABLE TARGET_TRIPLE
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  message (STATUS "Compiler target: ${TARGET_TRIPLE}")
+  if(TARGET_TRIPLE MATCHES "-musl")
+    set(LINUX_MUSL TRUE)
+    message(STATUS "Using Linux musl libc")
+  endif()
 endif()
 
 if(OVERRIDE_JDBC_OS_NAME)
@@ -101,9 +112,9 @@ add_jar(duckdb_jdbc_tests ${JAVA_TEST_FILES} INCLUDE_JARS duckdb_jdbc_nolib)
 
 # main shared lib compilation
 
-# Match ENABLE_JEMALLOC in duckdb/duckdb: 64-bit Linux only. On macOS jemalloc's src/zone.c
+# Match ENABLE_JEMALLOC in duckdb/duckdb: 64-bit glibc Linux only. On macOS jemalloc's src/zone.c
 # registers a malloc zone at dlopen time, aborting threads that free during the update.
-if(MSVC OR ZOS OR APPLE)
+if(MSVC OR ZOS OR APPLE OR LINUX_MUSL)
   set(JEMALLOC_ENABLED FALSE)
 else()
   set(JEMALLOC_ENABLED TRUE)


### PR DESCRIPTION
This is a backport of the PR #860 to `v1.5.5` stable branch.