### PR TITLE
Mark all Java scalar UDFs as fallible

### DIFF
--- a/src/jni/bindings_scalar_function.cpp
+++ b/src/jni/bindings_scalar_function.cpp
@@ -181,6 +181,11 @@ JNIEXPORT jint JNICALL Java_org_duckdb_DuckDBBindings_duckdb_1register_1scalar_1
 	if (env->ExceptionCheck()) {
 		return static_cast<jint>(DuckDBError);
 	}
+
+	// TODO: use C API V2 for this
+	duckdb::ScalarFunction &sf = *reinterpret_cast<duckdb::ScalarFunction *>(function);
+	sf.SetFallible();
+
 	return static_cast<jint>(duckdb_register_scalar_function(conn, function));
 }
 


### PR DESCRIPTION
Java user-defined functions invocation can throw a Java exception - this is a fully supported scenario. In 2.0 scalar functions must be explicitly marked as "fallible" to be able to propagate the native error outside of the function.

The API for setting function "fallible" is not available in C API V1 on which Java UDFs are implemented. This PR marks all Java UDFs as "fallible" using C++ API as a temporary measure. This logic should be moved to C API V2 in future.