### PR TITLE
Set output UDF records to be NULL by default (1.5)

### DIFF
--- a/src/main/java/org/duckdb/DuckDBWritableVector.java
+++ b/src/main/java/org/duckdb/DuckDBWritableVector.java
@@ -51,8 +51,13 @@ public final class DuckDBWritableVector {
         this.data = duckdb_vector_get_data_zeroed(vectorRef, Math.multiplyExact(rowCount, typeInfo.widthBytes))
                         .order(NATIVE_ORDER);
         duckdb_vector_ensure_validity_writable(vectorRef);
-        this.validity = duckdb_vector_get_validity(vectorRef, rowCount);
-        this.validity.order(NATIVE_ORDER);
+        ByteBuffer validity = duckdb_vector_get_validity(vectorRef, rowCount);
+        validity.order(NATIVE_ORDER);
+        while (validity.remaining() > 0) {
+            validity.putLong(0);
+        }
+        validity.clear();
+        this.validity = validity;
     }
 
     public DuckDBColumnType getType() {

--- a/src/test/java/org/duckdb/TestScalarFunctions.java
+++ b/src/test/java/org/duckdb/TestScalarFunctions.java
@@ -2507,14 +2507,17 @@ public class TestScalarFunctions {
                 assertTrue(rs.next());
                 assertEquals(rs.getString(1), "42");
                 assertTrue(rs.next());
-                assertEquals(rs.getString(1), "");
+                assertEquals(rs.getString(1), null);
+                assertTrue(rs.wasNull());
                 assertFalse(rs.next());
             }
             try (ResultSet rs = stmt.executeQuery("SELECT gen_corrupted_string(r) FROM range(43, 45) AS t(r)")) {
                 assertTrue(rs.next());
-                assertEquals(rs.getString(1), "");
+                assertEquals(rs.getString(1), null);
+                assertTrue(rs.wasNull());
                 assertTrue(rs.next());
-                assertEquals(rs.getString(1), "");
+                assertEquals(rs.getString(1), null);
+                assertTrue(rs.wasNull());
                 assertFalse(rs.next());
             }
         }


### PR DESCRIPTION
This is a backport of the PR #866 to `v1.5.5` stable branch.