### PR TITLE
Update vendored DuckDB sources to 9ef68611ca

### DIFF
--- a/src/duckdb/src/function/table/version/pragma_version.cpp
+++ b/src/duckdb/src/function/table/version/pragma_version.cpp
@@ -1,5 +1,5 @@
 #ifndef DUCKDB_PATCH_VERSION
-#define DUCKDB_PATCH_VERSION "6-dev144"
+#define DUCKDB_PATCH_VERSION "6-dev148"
 #endif
 #ifndef DUCKDB_MINOR_VERSION
 #define DUCKDB_MINOR_VERSION 5
@@ -8,10 +8,10 @@
 #define DUCKDB_MAJOR_VERSION 1
 #endif
 #ifndef DUCKDB_VERSION
-#define DUCKDB_VERSION "v1.5.6-dev144"
+#define DUCKDB_VERSION "v1.5.6-dev148"
 #endif
 #ifndef DUCKDB_SOURCE_ID
-#define DUCKDB_SOURCE_ID "f3be2750f5"
+#define DUCKDB_SOURCE_ID "9ef68611ca"
 #endif
 #include "duckdb/function/table/system_functions.hpp"
 #include "duckdb/main/database.hpp"

--- a/src/duckdb/src/parallel/pipeline_executor.cpp
+++ b/src/duckdb/src/parallel/pipeline_executor.cpp
@@ -78,26 +78,21 @@ bool PipelineExecutor::TryFlushCachingOperators(ExecutionBudget &chunk_budget) {
 		    flushing_idx + 1 >= intermediate_chunks.size() ? final_chunk : *intermediate_chunks[flushing_idx + 1];
 		auto &current_operator = pipeline.operators[flushing_idx].get();
 
-		OperatorFinalizeResultType finalize_result;
+		// In-process operators here mean an earlier push of curr_chunk was interrupted (the chunk budget
+		// ran out, or the Sink blocked). We resume that push rather than flushing the operator again, and
+		// leave should_flush_current_idx alone: it still reflects the last actual FinalExecute.
+		const bool resuming_push = !in_process_operators.empty();
 
-		if (in_process_operators.empty()) {
+		if (!resuming_push) {
 			curr_chunk.Reset();
 			StartOperator(current_operator);
-			finalize_result = current_operator.FinalExecute(context, curr_chunk, *current_operator.op_state,
-			                                                *intermediate_states[flushing_idx]);
+			auto finalize_result = current_operator.FinalExecute(context, curr_chunk, *current_operator.op_state,
+			                                                     *intermediate_states[flushing_idx]);
 			EndOperator(current_operator, &curr_chunk);
-		} else {
-			// Reset flag and reflush the last chunk we were flushing.
-			finalize_result = OperatorFinalizeResultType::HAVE_MORE_OUTPUT;
+			should_flush_current_idx = finalize_result == OperatorFinalizeResultType::HAVE_MORE_OUTPUT;
 		}
 
 		auto push_result = ExecutePushInternal(curr_chunk, chunk_budget, flushing_idx + 1);
-
-		if (finalize_result == OperatorFinalizeResultType::HAVE_MORE_OUTPUT) {
-			should_flush_current_idx = true;
-		} else {
-			should_flush_current_idx = false;
-		}
 
 		switch (push_result) {
 		case OperatorResultType::BLOCKED: {

--- a/src/duckdb/src/storage/wal_replay.cpp
+++ b/src/duckdb/src/storage/wal_replay.cpp
@@ -382,6 +382,8 @@ void WriteAheadLogReplayer::MergeIntoRecoveryWAL(Connection &con, const ReplaySt
 	// move over the recovery WAL over the main WAL
 	recovery_handle->Sync();
 	recovery_handle.reset();
+	// the main WAL is the target of the move - Windows refuses to replace a file that is still open
+	main_wal_reader.handle.reset();
 
 	if (debug_checkpoint_abort == CheckpointAbort::DEBUG_ABORT_BEFORE_MOVING_RECOVERY) {
 		throw FatalException("Checkpoint aborted before moving recovery file because of PRAGMA checkpoint_abort flag");
@@ -496,7 +498,10 @@ unique_ptr<WriteAheadLog> WriteAheadLogReplayer::ReplayLog(unique_ptr<FileHandle
 				}
 				// if this is not a read-only connection we need to finish the checkpoint
 				// overwrite the current WAL with the checkpoint WAL
+				// both files must be closed - Windows refuses to move a file that is still open, and refuses to
+				// replace a target that is still open
 				checkpoint_handle.reset();
+				reader.handle.reset();
 
 				fs.MoveFile(checkpoint_wal, wal_path);
 


### PR DESCRIPTION
Changes:
 - [duckdb/duckdb#9ef68611ca](https://github.com/duckdb/duckdb/commit/9ef68611ca) imported at 2026-09-11 05:38:02
